### PR TITLE
스프링 시큐리티 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 	implementation "org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE"
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'

--- a/src/main/java/udodog/goGetterServer/config/SpringSecurityConfig.java
+++ b/src/main/java/udodog/goGetterServer/config/SpringSecurityConfig.java
@@ -1,0 +1,30 @@
+package udodog.goGetterServer.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedMethod(CorsConfiguration.ALL);
+        configuration.addAllowedHeader(CorsConfiguration.ALL);
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        http
+                .formLogin().disable()
+                .csrf().disable()
+                .cors().configurationSource(source);
+    }
+}


### PR DESCRIPTION
[Spring Security] 스프링 시큐리티 설정

### 작업 사항
- 스프링 시큐리티 의존성 추가
- 스프링 시큐리티 CORS 설정

### 요약

서로 다른 도메인에서 REST API를 호출 할 경우, 즉 리소스를 호출할 경우 CORS 에러가 발생함
이를 해결하기 위해서는 스프링 시큐리티 설정을 통하여 프론트 서버에서 정상적으로 리소스에 접근하도록 수정해줘야함.

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈

resolved: #18 