### PR TITLE
Feat #38 : BlackMember 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,16 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+<<<<<<< Updated upstream
+=======
+	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
+	implementation "io.springfox:springfox-boot-starter:3.0.0"
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+>>>>>>> Stashed changes
 
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'

--- a/src/main/java/udodog/goGetterServer/controller/api/blackmember/BlackMemberManagementController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/blackmember/BlackMemberManagementController.java
@@ -1,0 +1,63 @@
+package udodog.goGetterServer.controller.api.blackmember;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import udodog.goGetterServer.model.converter.blackmember.BlackMemberEntityToModelConvertor;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.response.BlackMemberManagementResDto;
+import udodog.goGetterServer.model.entity.BlackMemberManagement;
+import udodog.goGetterServer.service.blackmember.BlackMemberManagementService;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@Api(tags = {"Black 회원 관리 API"})
+@RestController
+@RequiredArgsConstructor
+public class BlackMemberManagementController {
+
+    private final BlackMemberEntityToModelConvertor blackMemberEntityToModelConvertor;
+    private final BlackMemberManagementService blackMemberManagementService;
+
+//    @ApiOperation(value = "블랙 회원 등록 API", notes = "블랙회원 등록 시 사용되는 API")
+//    @ApiResponses(value ={@ApiResponse(code = 200, message = "1. 등록성공 \t\n 2. 등록실패")})
+//
+//    @PostMapping("/admapi/blackmembers")    // Http Method 및 URI 설정
+//    public ResponseEntity<EntityModel<DefaultRes<BlackMemberManagement>>> insertBlackMember(HttpServletRequest request, @RequestParam("userId") Long userId) { // Black 회원 등록
+//        BlackMemberManagement bmm = new BlackMemberManagement();
+//
+//        return ResponseEntity.ok(blackMemberEntityToModelConvertor.toModel(
+//                DefaultRes.response(HttpStatus.OK.value(), "Black List 회원이 추가되었습니다!", bmm)
+//        ));
+
+//    } // insertBlackMember() 끝
+    @ApiOperation(value = "블랙 회원 전체 조회 기능", notes = "Black Member 전체조회 기능 및 페이징 처리)")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "1.조회 성공 \t\n 2.토큰 에러 \t\n 3.데이터 없음")})
+
+    @GetMapping("/admapi/blackmembers")
+    public ResponseEntity<EntityModel<DefaultRes<List<BlackMemberManagementResDto>>>> searchBlackMember(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC, size = 15)Pageable pageable) { // Black 회원 조회 페이징 처리
+
+        //        BlackMemberManagement bmm = new BlackMemberManagement();
+
+        return new ResponseEntity<>(blackMemberEntityToModelConvertor
+                                          .toModel(blackMemberManagementService.findAllBlackMember(pageable)), HttpStatus.OK);
+    }  // searchBlackMember() 끝
+
+
+
+
+} // Class 끝

--- a/src/main/java/udodog/goGetterServer/model/converter/blackmember/BlackMemberEntityToModelConvertor.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/blackmember/BlackMemberEntityToModelConvertor.java
@@ -1,0 +1,25 @@
+package udodog.goGetterServer.model.converter.blackmember;
+
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+import udodog.goGetterServer.controller.api.blackmember.BlackMemberManagementController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.response.BlackMemberManagementResDto;
+
+import java.util.List;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class BlackMemberEntityToModelConvertor implements RepresentationModelAssembler<DefaultRes<List<BlackMemberManagementResDto>>, EntityModel<DefaultRes<List<BlackMemberManagementResDto>>>> {
+
+    @Override
+    public EntityModel<DefaultRes<List<BlackMemberManagementResDto>>> toModel(DefaultRes<List<BlackMemberManagementResDto>> defaultRes) {
+        return EntityModel.of(defaultRes,
+                linkTo(methodOn(BlackMemberManagementController.class).searchBlackMember(null)).withSelfRel(),
+                linkTo(methodOn(BlackMemberManagementController.class).searchBlackMember(null)).withRel("seach"));
+    } // toModel() 끝
+} // Class 끝

--- a/src/main/java/udodog/goGetterServer/model/dto/response/BlackMemberManagementResDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/BlackMemberManagementResDto.java
@@ -1,0 +1,29 @@
+package udodog.goGetterServer.model.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import udodog.goGetterServer.model.entity.User;
+
+@Getter
+@RequiredArgsConstructor
+public class BlackMemberManagementResDto {
+
+    private Long userId;
+
+    private String name;
+
+    private String nickName;
+
+    private String email;
+
+    private String phoneNumber;
+
+    public BlackMemberManagementResDto(User user) { // User 객체를 받기 위한 생성자
+        this.userId = user.getId();
+        this.name = user.getName();
+        this.nickName = user.getNickName();
+        this.email = user.getEmail();
+        this.phoneNumber = user.getPhoneNumber();
+    } // 생성자 끝
+
+} // Class 끝

--- a/src/main/java/udodog/goGetterServer/repository/BlackMemberManagementRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/BlackMemberManagementRepository.java
@@ -1,7 +1,11 @@
 package udodog.goGetterServer.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import udodog.goGetterServer.model.entity.BlackMemberManagement;
 
 public interface BlackMemberManagementRepository extends JpaRepository<BlackMemberManagement, Long> {
+
+    Page<BlackMemberManagement> findByAll(Pageable pageable);
 } // Class 끝

--- a/src/main/java/udodog/goGetterServer/service/blackmember/BlackMemberManagementService.java
+++ b/src/main/java/udodog/goGetterServer/service/blackmember/BlackMemberManagementService.java
@@ -1,0 +1,45 @@
+package udodog.goGetterServer.service.blackmember;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.Pagination;
+import udodog.goGetterServer.model.dto.response.BlackMemberManagementResDto;
+import udodog.goGetterServer.model.entity.BlackMemberManagement;
+import udodog.goGetterServer.repository.BlackMemberManagementRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlackMemberManagementService {
+
+    private final BlackMemberManagementRepository blackMemberManagementRepository;      // 블랙 회원 Repository 사용을 위한 인스턴스 변수 선언
+
+
+    public List<BlackMemberManagementResDto> res(Page<BlackMemberManagement> page) {
+
+        List<BlackMemberManagementResDto> noticeList = page.stream().map(p -> )     collect(Collectors.toList());
+
+        return noticeList;
+    }
+
+
+    public DefaultRes<List<BlackMemberManagementResDto>> findAllBlackMember(Pageable pageable) {
+
+        Page<BlackMemberManagement> blackMemberPage = blackMemberManagementRepository.findByAll(pageable);
+
+        if(blackMemberPage.getTotalElements() == 0) {
+            return DefaultRes.response(HttpStatus.OK.value(), "정보없음");
+
+        } else {
+            return DefaultRes.response(HttpStatus.OK.value(), "조회성공", res(blackMemberPage), new Pagination(blackMemberPage));
+        }
+    }
+
+
+} // Class 끝

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: junyharang8592@gmail.com
+    password: Juny3170!#%
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+springdoc:
+  paths-to-exclude=/swagger-resources/**:

--- a/src/test/java/udodog/goGetterServer/repository/BlackMemberManagementTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/BlackMemberManagementTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class BlackMemberManagementRepositoryTest {
+class BlackMemberManagementRequestRepositoryTest {
 
     @Autowired private UserRepository userRepository;
 

--- a/src/test/java/udodog/goGetterServer/repository/CouponRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/CouponRepositoryTest.java
@@ -31,3 +31,4 @@ class CouponRepositoryTest {
         Assertions.assertThat(coupon).isEqualTo(saveCoupon);
     }
 }
+


### PR DESCRIPTION
[BlackMemberManagement] Black Member 조회 API 구현

작업 사항

이메일 인증 API 구현
발급번호 체크 API 구현
회원가입 API 구현
요약

Gmail SMTP를 활용하여 메일 전송 시스템 구현
메일 전송 부분 비동기 처리 -> 클라이언트에게 응답은 빠르게 처리해주고 메일 전송 로직은 멀티 쓰레드를 활용
세션에 발급 번호를 저장(유효기간 5분)
유효성 검사 클래스 추가 ExceptionAdvisor
스웨거 버전 2.9.2 -> 3.0.0 Up
첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

이슈

issued : #23 #24 #31 #30 #26