### PR TITLE
[Jwt Token] Jwt 의존성 추가, Util 클래스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
 	implementation "io.springfox:springfox-boot-starter:3.0.0"
-
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
 	implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.4.1'
     implementation 'junit:junit:4.13.1'
 
@@ -39,6 +37,11 @@ dependencies {
 
 	testCompileOnly 'org.projectlombok:lombok:1.18.12'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+
+	// jwt 관련 의존성
+	implementation 'io.jsonwebtoken:jjwt-api:0.10.7'
+	runtimeElements 'io.jsonwebtoken:jjwt-impl:0.10.7'
+	runtimeElements 'io.jsonwebtoken:jjwt-jackson:0.10.7'
 }
 
 test {

--- a/src/main/java/udodog/goGetterServer/config/SpringSecurityConfig.java
+++ b/src/main/java/udodog/goGetterServer/config/SpringSecurityConfig.java
@@ -1,15 +1,21 @@
 package udodog.goGetterServer.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import udodog.goGetterServer.model.utils.JwtUtil;
 
 @Configuration
 @EnableWebSecurity
 public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -27,4 +33,10 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf().disable()
                 .cors().configurationSource(source);
     }
+
+    @Bean
+    public JwtUtil jwtUtil(){
+        return new JwtUtil(secret);
+    }
+
 }

--- a/src/main/java/udodog/goGetterServer/model/utils/JwtUtil.java
+++ b/src/main/java/udodog/goGetterServer/model/utils/JwtUtil.java
@@ -1,0 +1,74 @@
+package udodog.goGetterServer.model.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import udodog.goGetterServer.model.enumclass.UserGrade;
+
+import java.security.Key;
+import java.util.Date;
+
+public class JwtUtil {
+
+    private static Key key;
+
+    //리프레시 토큰 유효시간 24시간(ms단위)
+    public static Long REFRESH_TOKEN_VALID_TIME = 1440 * 60 * 1000L;
+
+    //엑세스 토큰 유효시간 30분
+    public static Long ACCESS_TOKEN_VALID_TIME =  30 * 60 * 1000L;
+
+    public static String ACCESS_TOKEN_NAME = "ACCESS TOKEN";
+
+    public static String REFRESH_TOKEN_NAME = "REFRESH TOKEN";
+
+    public JwtUtil(String secret) {
+        key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    //엑세스 토큰 발급
+    public static String createAccessToken(Long userId, UserGrade userGrade){
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .claim("user_pk", userId) //정보 저장
+                .claim("user_grade", userGrade)
+                .claim("token_name", ACCESS_TOKEN_NAME)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+    }
+
+    //리프레쉬 토큰 발급
+    public static String createRefreshToken(Long userId,UserGrade userGrade){
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .claim("user_pk", userId) //정보 저장
+                .claim("user_grade", userGrade)
+                .claim("token_name", ACCESS_TOKEN_NAME)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALID_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+    }
+
+    // 토큰의 유효성 + 만료일자 확인
+    public static Claims getClaims(String token) {
+        try{
+            return Jwts.parser()
+                    .setSigningKey(key)
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        }catch (Exception e){
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### 작업 사항

- Jwt 의존성 추가
- Jwt Util 클래스 구현 (엑세스토큰 발급, 리프레시 토큰 발급, 토큰 유효성 검사)
- application.yml 키 등록(시그니처)

### 요약

Jwt 토큰 전략을 활용하여 인가 처리를 합니다.
리프레쉬 토큰의 유효기간은 24시간, 엑세스 토큰의 유효기간은 5분입니다.
<시나리오>
1. 첫 로그인 시 엑세스 토큰, 리프레시 토큰 발급
  1.1 서버는 리프레시 토큰을 User 테이블에 저장 ( 중복로그인 방지, 보안)
  1.2 클라이언트는 리프레시 토큰과 엑세스 토큰을 로컬 스토리지에 저장

2. 권한이 필요한 API를 호출할 경우 로컬 스토리지에서 엑세스 토큰을 꺼내 HTTP 헤더에 담아서 요청

3. 서버 인터셉터에서 엑세트 토큰이 유효할 경우 API 비지니스 로직 수행 후 응답
  3.1 엑세스 토큰이 유효하지 않을 경우 토큰만료 응답처리

4. 클라이언트는 토큰만료 응답을 받게되면 로컬 스토리지에서 리프레시 토큰을 꺼내 HTTP 헤더에 담아 엑세스 토큰 재발급 요청

5. 서버 인터셉터에서 리프레시 토큰으로 요청이 오면 리프레시 토큰에 대해 권한이 있는 지 없는 지 체크
  5.1 리프레시 토큰이 권한이 있는 경우에는 엑세스 토큰을 재발급하여 클라이언트에게 응답
  5.2 리프레시 토큰에 권한이 없는 경우에는 토큰만료 응답처리

6. 클라이언트는 엑세스 토큰을 재발급 받은 경우 다시 이 엑세스토큰을 로컬 스토리지에 저장 후 기존 요청하려던 API를 재호출
  6.1 토큰만료를 응답 받으면 로그아웃 처리 로컬 스토리지에 엑세스토큰과 리프레시 토큰 삭제

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈

issued : #45 