### PR TITLE
[Jwt-Authorization] 인터셉터를 활용한 JWT 인가처리

### DIFF
--- a/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
+++ b/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
@@ -4,19 +4,39 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import udodog.goGetterServer.controller.interceptor.AdmApiInterceptor;
 import udodog.goGetterServer.controller.interceptor.BkUserApiInterceptor;
+import udodog.goGetterServer.controller.interceptor.UserApiInterceptor;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+
         registry.addInterceptor(bkUserApiInterceptor())
                 .addPathPatterns("/api/bkusers/**");
+
+        registry.addInterceptor(userApiInterceptor())
+                .addPathPatterns("/api/users/**");
+
+        registry.addInterceptor(admApiInterceptor())
+                .addPathPatterns("/api/admin/**");
+
     }
 
     @Bean
     public BkUserApiInterceptor bkUserApiInterceptor(){
         return new BkUserApiInterceptor();
+    }
+
+    @Bean
+    public UserApiInterceptor userApiInterceptor(){
+        return new UserApiInterceptor();
+    }
+
+    @Bean
+    public AdmApiInterceptor admApiInterceptor(){
+        return new AdmApiInterceptor();
     }
 }

--- a/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
+++ b/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package udodog.goGetterServer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import udodog.goGetterServer.controller.interceptor.BkUserApiInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(bkUserApiInterceptor())
+                .addPathPatterns("/api/bkusers/**");
+    }
+
+    @Bean
+    public BkUserApiInterceptor bkUserApiInterceptor(){
+        return new BkUserApiInterceptor();
+    }
+}

--- a/src/main/java/udodog/goGetterServer/controller/api/user/UserController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/user/UserController.java
@@ -73,9 +73,4 @@ public class UserController {
         return new ResponseEntity<>(userConverter.toModel(userService.signIn(requestDto)), HttpStatus.OK);
     }
 
-    @GetMapping("/bkusers/hello")
-    public String hello(){
-        return "ok";
-    }
-
 }

--- a/src/main/java/udodog/goGetterServer/controller/api/user/UserController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/user/UserController.java
@@ -73,4 +73,9 @@ public class UserController {
         return new ResponseEntity<>(userConverter.toModel(userService.signIn(requestDto)), HttpStatus.OK);
     }
 
+    @GetMapping("/bkusers/hello")
+    public String hello(){
+        return "ok";
+    }
+
 }

--- a/src/main/java/udodog/goGetterServer/controller/interceptor/AdmApiInterceptor.java
+++ b/src/main/java/udodog/goGetterServer/controller/interceptor/AdmApiInterceptor.java
@@ -1,0 +1,74 @@
+package udodog.goGetterServer.controller.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import udodog.goGetterServer.model.dto.response.user.JwtAccessTokenResponse;
+import udodog.goGetterServer.model.enumclass.UserGrade;
+import udodog.goGetterServer.model.utils.JwtUtil;
+import udodog.goGetterServer.service.user.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AdmApiInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            response.sendError(401,"요청에러");
+            return false;
+        }
+
+        String jwtToken = token.substring("Bearer ".length());
+        Claims claims = JwtUtil.getClaims(jwtToken);
+        if (claims == null){
+            response.sendError(401,"엑세스토큰 불일치");
+            return false;
+        }
+
+        String tokenName = claims.get("token_name", String.class);
+        String userGrade = claims.get("user_grade", String.class);
+
+        if (userGrade.equals(UserGrade.BLACK.name()) || userGrade.equals(UserGrade.USER.name())){
+            response.sendError(403,"권한없음");
+            return false;
+        }
+
+        if(tokenName.equals(JwtUtil.ACCESS_TOKEN_NAME)){
+            return true;
+        }else if(tokenName.equals(JwtUtil.REFRESH_TOKEN_NAME)){
+            Long userPk = claims.get("user_pk", Long.class);
+            Boolean check = sessionService.refreshTokenCheck(userPk, jwtToken);
+            if(check){
+                String accessToken = JwtUtil.createAccessToken(userPk, UserGrade.ADMIN);
+                accessTokenResponse(response, accessToken);
+                return false;
+            }else{
+                response.sendError(401,"리프레시토큰 불일치");
+            }
+
+        }
+
+        response.sendError(401, "토큰에러");
+        return false;
+    }
+
+    private void accessTokenResponse(HttpServletResponse response, String accessToken) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JwtAccessTokenResponse jwtAccessTokenResponse = new JwtAccessTokenResponse("엑세스토큰 재발급", accessToken);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+        response.getWriter().write(mapper.writeValueAsString(jwtAccessTokenResponse));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/controller/interceptor/BkUserApiInterceptor.java
+++ b/src/main/java/udodog/goGetterServer/controller/interceptor/BkUserApiInterceptor.java
@@ -1,0 +1,77 @@
+package udodog.goGetterServer.controller.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import udodog.goGetterServer.model.dto.response.user.JwtAccessTokenResponse;
+import udodog.goGetterServer.model.enumclass.UserGrade;
+import udodog.goGetterServer.model.utils.JwtUtil;
+import udodog.goGetterServer.service.user.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class BkUserApiInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            response.sendError(401,"요청에러");
+            return false;
+        }
+
+        String jwtToken = token.substring("Bearer ".length());
+        Claims claims = JwtUtil.getClaims(jwtToken);
+        if (claims == null){
+            response.sendError(401,"엑세스토큰 불일치");
+            return false;
+        }
+
+        String tokenName = claims.get("token_name", String.class);
+        String userGrade = claims.get("user_grade", String.class);
+
+        if(tokenName.equals(JwtUtil.ACCESS_TOKEN_NAME)){
+            return true;
+        }else if(tokenName.equals(JwtUtil.REFRESH_TOKEN_NAME)){
+            Long userPk = claims.get("user_pk", Long.class);
+            Boolean check = sessionService.refreshTokenCheck(userPk, jwtToken);
+            if(check){
+                String accessToken;
+                if(userGrade.equals(UserGrade.ADMIN)){
+                    accessToken = JwtUtil.createAccessToken(userPk, UserGrade.ADMIN);
+                }else if(userGrade.equals(UserGrade.USER)){
+                    accessToken = JwtUtil.createAccessToken(userPk, UserGrade.USER);
+                }else{
+                    accessToken = JwtUtil.createAccessToken(userPk, UserGrade.BLACK);
+                }
+
+                accessTokenResponse(response, accessToken);
+                return false;
+            }else{
+                response.sendError(401,"리프레시토큰 불일치");
+            }
+
+        }
+
+        response.sendError(401, "토큰에러");
+        return false;
+    }
+
+    private void accessTokenResponse(HttpServletResponse response, String accessToken) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JwtAccessTokenResponse jwtAccessTokenResponse = new JwtAccessTokenResponse("엑세스토큰 재발급", accessToken);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+        response.getWriter().write(mapper.writeValueAsString(jwtAccessTokenResponse));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/controller/interceptor/UserApiInterceptor.java
+++ b/src/main/java/udodog/goGetterServer/controller/interceptor/UserApiInterceptor.java
@@ -1,0 +1,80 @@
+package udodog.goGetterServer.controller.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import udodog.goGetterServer.model.dto.response.user.JwtAccessTokenResponse;
+import udodog.goGetterServer.model.enumclass.UserGrade;
+import udodog.goGetterServer.model.utils.JwtUtil;
+import udodog.goGetterServer.service.user.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class UserApiInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            response.sendError(401,"요청에러");
+            return false;
+        }
+
+        String jwtToken = token.substring("Bearer ".length());
+        Claims claims = JwtUtil.getClaims(jwtToken);
+        if (claims == null){
+            response.sendError(401,"엑세스토큰 불일치");
+            return false;
+        }
+
+        String tokenName = claims.get("token_name", String.class);
+        String userGrade = claims.get("user_grade", String.class);
+
+        if (userGrade.equals(UserGrade.BLACK.name())){
+            response.sendError(403,"권한없음");
+            return false;
+        }
+
+        if(tokenName.equals(JwtUtil.ACCESS_TOKEN_NAME)){
+            return true;
+        }else if(tokenName.equals(JwtUtil.REFRESH_TOKEN_NAME)){
+            Long userPk = claims.get("user_pk", Long.class);
+            Boolean check = sessionService.refreshTokenCheck(userPk, jwtToken);
+            if(check){
+                String accessToken;
+                if(userGrade.equals(UserGrade.ADMIN)){
+                    accessToken = JwtUtil.createAccessToken(userPk, UserGrade.ADMIN);
+                }else{
+                    accessToken = JwtUtil.createAccessToken(userPk, UserGrade.USER);
+                }
+
+                accessTokenResponse(response, accessToken);
+                return false;
+            }else{
+                response.sendError(401,"리프레시토큰 불일치");
+            }
+
+        }
+
+        response.sendError(401, "토큰에러");
+        return false;
+    }
+
+    private void accessTokenResponse(HttpServletResponse response, String accessToken) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JwtAccessTokenResponse jwtAccessTokenResponse = new JwtAccessTokenResponse("엑세스토큰 재발급", accessToken);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+        response.getWriter().write(mapper.writeValueAsString(jwtAccessTokenResponse));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/response/user/JwtAccessTokenResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/user/JwtAccessTokenResponse.java
@@ -1,0 +1,16 @@
+package udodog.goGetterServer.model.dto.response.user;
+
+import lombok.Getter;
+
+@Getter
+public class JwtAccessTokenResponse {
+
+    private String message;
+
+    private String accessToken;
+
+    public JwtAccessTokenResponse(String message, String accessToken) {
+        this.message = message;
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/utils/JwtUtil.java
+++ b/src/main/java/udodog/goGetterServer/model/utils/JwtUtil.java
@@ -16,8 +16,8 @@ public class JwtUtil {
     //리프레시 토큰 유효시간 24시간(ms단위)
     public static Long REFRESH_TOKEN_VALID_TIME = 1440 * 60 * 1000L;
 
-    //엑세스 토큰 유효시간 30분
-    public static Long ACCESS_TOKEN_VALID_TIME =  30 * 60 * 1000L;
+    //엑세스 토큰 유효시간 5분
+    public static Long ACCESS_TOKEN_VALID_TIME =  5 * 60 * 1000L;
 
     public static String ACCESS_TOKEN_NAME = "ACCESS TOKEN";
 
@@ -51,7 +51,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .claim("user_pk", userId) //정보 저장
                 .claim("user_grade", userGrade)
-                .claim("token_name", ACCESS_TOKEN_NAME)
+                .claim("token_name", REFRESH_TOKEN_NAME)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALID_TIME))
                 .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/udodog/goGetterServer/service/user/SessionService.java
+++ b/src/main/java/udodog/goGetterServer/service/user/SessionService.java
@@ -1,0 +1,28 @@
+package udodog.goGetterServer.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.entity.User;
+import udodog.goGetterServer.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final UserRepository userRepository;
+
+    public Boolean refreshTokenCheck(Long id, String refreshToken){
+        Optional<User> optionalUser = userRepository.findById(id);
+
+        return optionalUser.map(user -> {
+            if(user.getToken().equals(refreshToken)){
+                return true;
+            }else{
+                return false;
+            }
+        }).orElse(false);
+    }
+
+}


### PR DESCRIPTION
### 작업 사항
- 관리자 등급 API 인터셉터 구현
- 일반회원 등급 API 인터셉터 구현
- 블랙회원 등급 API 인터셉터 구현

### 요약

엑세스 토큰과 리프레시 토큰을 활용한 인가처리

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈

issued : #37