### PR TITLE
feat #27, #33, #44, #57, #58, #63, #64, #73, #76, #78: 토론게시판, 토론게시판 댓글, 토론게시판 검색 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionController.java
@@ -90,4 +90,40 @@ public class DiscussionController {
     public ResponseEntity<EntityModel<DefaultRes<DiscussionDetailResponse>>> deleteBoard (@RequestParam("id") Long id, @RequestParam("userId") Long userId){
         return new ResponseEntity<>(discussionConvertor.toModel(discussionService.delete(id, userId)), HttpStatus.OK);
     }
+
+    @ApiOperation(value = "토론게시판 제목 검색 API",notes = "제목 검색 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1.검색성공 \\t\\n 2. 데이터없음 \\t\\n 3. 토큰에러")
+    })
+
+    // 제목으로 검색
+    @GetMapping("/api/discussions/search-title")
+    public ResponseEntity<EntityModel<DefaultRes<List<DiscussionReseponseDto>>>> searchTitle (@RequestParam("title") String title,
+                                                                            @PageableDefault(sort = "createAt", direction = Sort.Direction.DESC, size = 7) Pageable pageable){
+        return new ResponseEntity<>(discussionListConvertor.toModel(discussionService.searchTitle(title, pageable)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "토론게시판 내용 검색 API",notes = "내용 검색 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1.검색성공 \\t\\n 22. 데이터없음 \\t\\n 3. 토큰에러")
+    })
+
+    // 내용으로 검색
+    @GetMapping("/api/discussions/search-content")
+    public ResponseEntity<EntityModel<DefaultRes<List<DiscussionReseponseDto>>>> searchContent (@RequestParam("content") String content,
+                                                                                              @PageableDefault(sort = "createAt", direction = Sort.Direction.DESC, size = 7) Pageable pageable){
+        return new ResponseEntity<>(discussionListConvertor.toModel(discussionService.searchContent(content, pageable)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "토론게시판 제목+내용 검색 API",notes = "제목+내용 검색 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1.검색성공 \\t\\n 2. 데이터없음 \\t\\n 3. 토큰에러")
+    })
+
+    // 제목 + 내용으로 검색
+    @GetMapping("/api/discussions/search-all")
+    public ResponseEntity<EntityModel<DefaultRes<List<DiscussionReseponseDto>>>> searchAll (@RequestParam("search") String search,
+                                                                                                @PageableDefault(sort = "createAt", direction = Sort.Direction.DESC, size = 7) Pageable pageable){
+        return new ResponseEntity<>(discussionListConvertor.toModel(discussionService.searchAll(search, pageable)), HttpStatus.OK);
+    }
 }

--- a/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionReplyController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionReplyController.java
@@ -1,0 +1,86 @@
+package udodog.goGetterServer.controller.api.discussion;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import udodog.goGetterServer.model.converter.discussion.DiscussionReplyConvertor;
+import udodog.goGetterServer.model.converter.discussion.DiscussionReplyListConvertor;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.discussion.DiscussionReplyEditRequest;
+import udodog.goGetterServer.model.dto.request.discussion.DiscussionReplyInsertRequest;
+import udodog.goGetterServer.model.dto.response.discussion.DiscussionReplyResponse;
+import udodog.goGetterServer.model.entity.DiscussionBoardReply;
+import udodog.goGetterServer.service.discussion.DiscussionReplyService;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Api(tags = {"토론 게시판 댓글 관련 API"})
+@RestController
+@RequiredArgsConstructor
+public class DiscussionReplyController {
+
+    private final DiscussionReplyListConvertor replyListConvertor;
+    private final DiscussionReplyConvertor replyConvertor;
+    private final DiscussionReplyService replyService;
+
+    @ApiOperation(value = "토론게시판 댓글 등록 API",notes = "댓글 등록 API 입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 등록성공 \t\n 2. 등록실패 \t\n 3. 토큰에러")
+    })
+
+    // 글 등록 Controller
+    @PostMapping("/api/user/discussionreplies")
+    public ResponseEntity<EntityModel<DefaultRes<DiscussionReplyResponse>>> createReply(
+            @ApiParam("필수 : 모든사항")
+            @RequestBody DiscussionReplyInsertRequest requestDto){
+        return new ResponseEntity<>(replyConvertor.toModel(replyService.createReply(requestDto)), HttpStatus.OK);
+    }
+
+
+    @ApiOperation(value = "토론게시판 댓글 전체 목록 조회 API",notes = "댓글 전체 목록 조회 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 조회성공 \t\n 2. 데이터없음 \t\n 3. 토큰에러")
+    })
+
+    // 댓글 조회 Controller
+    @GetMapping("/api/bkuser/discussionreplies")
+    public ResponseEntity<EntityModel<DefaultRes<List<DiscussionReplyResponse>>>> getBoardReplyList(
+            @RequestParam("discussionId") Long discussionId,
+            @PageableDefault(sort = "createAt", direction = Sort.Direction.DESC, size = 3) Pageable pageable // 최신 날짜순으로 내림차순, 페이지당 3개씩 출력
+    ){
+        return new ResponseEntity<>(replyListConvertor.toModel(replyService.getBoardReplyList(discussionId, pageable)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "토론게시판 댓글 수정 API",notes = "댓글 수정 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 수정성공 \t\n 2. 데이터없음 \t\n 3. 수정실패 \t\n 4. 토큰에러")
+    })
+
+    // 댓글 수정 Controller
+    @PutMapping("/api/user/discussionreplies")
+    public ResponseEntity<EntityModel<DefaultRes<DiscussionReplyEditRequest>>> updateReply(
+            @RequestParam("discussionId") Long discussionId,
+            @Valid@RequestBody DiscussionReplyEditRequest requestDto
+    ){
+        return new ResponseEntity<>(replyConvertor.toModel(replyService.updateReply(requestDto, discussionId)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "토론게시판 댓글삭제 API",notes = "댓글삭제 API입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1.삭제성공 \\t\\n 2. 삭제실패 \\t\\n 3. 데이터없음 \\t\\n 4. 토큰에러")
+    })
+
+    // 댓글 삭제 Controller
+    @DeleteMapping("/api/user/discussionreplies")
+    public ResponseEntity<EntityModel<DefaultRes<DiscussionBoardReply>>> deleteReply (@RequestParam("id") Long id,
+                                                                                      @RequestParam("userId") Long userId){
+        return new ResponseEntity<>(replyConvertor.toModel(replyService.delete(id, userId)), HttpStatus.OK);
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionListConvertor.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionListConvertor.java
@@ -22,7 +22,10 @@ public class DiscussionListConvertor implements RepresentationModelAssembler<Def
         return EntityModel.of(defaultRes,
                 linkTo(methodOn(DiscussionController.class).getBoardList(null)).withRel("list"),
                 linkTo(methodOn(DiscussionController.class).getDetailBoard(null)).withRel("detail"),
-                linkTo(methodOn(DiscussionController.class).insertBoard(null)).withRel("insert"));
+                linkTo(methodOn(DiscussionController.class).insertBoard(null)).withRel("insert"),
+                linkTo(methodOn(DiscussionController.class).searchTitle(null, null)).withRel("searchTitle"),
+                linkTo(methodOn(DiscussionController.class).searchContent(null, null)).withRel("searchContent"),
+                linkTo(methodOn(DiscussionController.class).searchAll(null, null)).withRel("searchAll"));
     }
 
 }

--- a/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionReplyConvertor.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionReplyConvertor.java
@@ -1,0 +1,24 @@
+package udodog.goGetterServer.model.converter.discussion;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+import udodog.goGetterServer.controller.api.discussion.DiscussionReplyController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.response.discussion.DiscussionReplyResponse;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class DiscussionReplyConvertor implements RepresentationModelAssembler<DefaultRes<DiscussionReplyResponse>,
+        EntityModel<DefaultRes<DiscussionReplyResponse>>> {
+
+    @Override
+    public EntityModel<DefaultRes<DiscussionReplyResponse>> toModel(DefaultRes<DiscussionReplyResponse> entity) {
+        return EntityModel.of(entity,
+                linkTo(methodOn(DiscussionReplyController.class).createReply(null)).withRel("replyInsert"),
+                linkTo(methodOn(DiscussionReplyController.class).updateReply(null,null)).withRel("replyUpdate"),
+                linkTo(methodOn(DiscussionReplyController.class).deleteReply(null, null)).withRel("replyDelete"));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionReplyListConvertor.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/discussion/DiscussionReplyListConvertor.java
@@ -1,0 +1,25 @@
+package udodog.goGetterServer.model.converter.discussion;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+import udodog.goGetterServer.controller.api.discussion.DiscussionReplyController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.response.discussion.DiscussionReplyResponse;
+
+import java.util.List;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class DiscussionReplyListConvertor implements RepresentationModelAssembler<DefaultRes<List<DiscussionReplyResponse>>,
+        EntityModel<DefaultRes<List<DiscussionReplyResponse>>>> {
+
+    @Override
+    public EntityModel<DefaultRes<List<DiscussionReplyResponse>>> toModel(DefaultRes<List<DiscussionReplyResponse>> entity) {
+        return EntityModel.of(entity,
+                linkTo(methodOn(DiscussionReplyController.class).getBoardReplyList(null, null)).withRel("list"),
+                linkTo(methodOn(DiscussionReplyController.class).createReply(null)).withRel("insert"));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/request/discussion/DiscussionReplyEditRequest.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/discussion/DiscussionReplyEditRequest.java
@@ -1,0 +1,18 @@
+package udodog.goGetterServer.model.dto.request.discussion;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class DiscussionReplyEditRequest {
+
+    @NotNull
+    Long userId;
+
+    @NotNull
+    private String content;
+
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/request/discussion/DiscussionReplyInsertRequest.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/discussion/DiscussionReplyInsertRequest.java
@@ -1,0 +1,35 @@
+package udodog.goGetterServer.model.dto.request.discussion;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import udodog.goGetterServer.model.entity.DiscussionBoard;
+import udodog.goGetterServer.model.entity.DiscussionBoardReply;
+import udodog.goGetterServer.model.entity.User;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@Getter
+public class DiscussionReplyInsertRequest {
+
+    @NotNull
+    @ApiModelProperty(value = "현재 게시판 정보")
+    private DiscussionBoard discussionBoard;
+
+    @NotNull
+    @ApiModelProperty(value = "로그인 상태의 사용자의 정보")
+    private User user;
+
+    @NotNull
+    private String content;
+
+    public DiscussionBoardReply toEntity(DiscussionReplyInsertRequest requestDto){
+        return DiscussionBoardReply.builder()
+                .discussionBoard(requestDto.discussionBoard)
+                .user(requestDto.user)
+                .content(requestDto.content)
+                .build();
+    }
+
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReplyResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReplyResponse.java
@@ -1,0 +1,30 @@
+package udodog.goGetterServer.model.dto.response.discussion;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import udodog.goGetterServer.model.entity.DiscussionBoard;
+import udodog.goGetterServer.model.entity.DiscussionBoardReply;
+import udodog.goGetterServer.model.entity.User;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class DiscussionReplyResponse {
+
+    private Long id;
+
+    private String userNickName;
+
+    private String content;
+
+    private LocalDate createAt;
+
+    public DiscussionReplyResponse(DiscussionBoardReply boardReply){
+
+        this.id = boardReply.getId();
+        this.userNickName = boardReply.getUser().getNickName();
+        this.content = boardReply.getContent();
+        this.createAt = boardReply.getCreateAt();
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReseponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReseponseDto.java
@@ -2,7 +2,6 @@ package udodog.goGetterServer.model.dto.response.discussion;
 
 import lombok.*;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
-import udodog.goGetterServer.model.entity.User;
 
 import java.time.LocalDate;
 
@@ -21,5 +20,4 @@ public class DiscussionReseponseDto {
         this.title = discussionBoard.getTitle();
         this.createAt = discussionBoard.getCreateAt();
     }
-
 }

--- a/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoard.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoard.java
@@ -9,6 +9,8 @@ import udodog.goGetterServer.model.dto.request.discussion.DiscussionEditRequest;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.LinkedList;
+import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
@@ -18,6 +18,7 @@ public class DiscussionBoardReadhit {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "discussion_id")
     private DiscussionBoard discussionBoard;
+
     int count;
 
     @Builder

--- a/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
@@ -19,11 +19,12 @@ public class DiscussionBoardReadhit {
     @JoinColumn(name = "discussion_id")
     private DiscussionBoard discussionBoard;
 
-    int count;
+    Integer count;
 
     @Builder
-    public DiscussionBoardReadhit(DiscussionBoard discussionBoard, int count) {
+    public DiscussionBoardReadhit(DiscussionBoard discussionBoard, Integer count) {
         this.discussionBoard = discussionBoard;
         this.count = count;
     }
+
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
@@ -1,7 +1,11 @@
 package udodog.goGetterServer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import udodog.goGetterServer.model.entity.DiscussionBoardReadhit;
 
 public interface DiscussionBoardReadhitRepository extends JpaRepository<DiscussionBoardReadhit,Long> {
+
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
@@ -3,5 +3,5 @@ package udodog.goGetterServer.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import udodog.goGetterServer.model.entity.DiscussionBoardReadhit;
 
-public interface DiscussonBoardReadhitRepository extends JpaRepository<DiscussionBoardReadhit,Long> {
+public interface DiscussionBoardReadhitRepository extends JpaRepository<DiscussionBoardReadhit,Long> {
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
@@ -26,4 +26,8 @@ public interface DiscussionBoardReplyRepository extends JpaRepository<Discussion
     @Modifying
     @Query(value = "delete from DiscussionBoardReply dr where dr.discussionBoard.id = :discussionId")
     void deleteByDiscussionId(Long discussionId);
+
+    @Query(value = "select count(dr) from DiscussionBoardReply dr where dr.discussionBoard.id = :discussionId")
+    Integer countReply(Long discussionId);
+
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
@@ -11,14 +11,16 @@ import udodog.goGetterServer.model.entity.DiscussionBoardReply;
 import java.util.Optional;
 
 
-public interface DiscussonBoardReplyRepository extends JpaRepository<DiscussionBoardReply, Long> {
+public interface DiscussionBoardReplyRepository extends JpaRepository<DiscussionBoardReply, Long> {
 
     @Query(value = "select dr from DiscussionBoardReply dr join fetch dr.discussionBoard d join fetch d.user where d.id= :id",
             countQuery = "select count(dr) from DiscussionBoardReply")
     Page<DiscussionBoardReply> findAllWithFetchJoin(Long id, Pageable pageable);
 
     @Query(value = "select dr from DiscussionBoardReply dr join fetch dr.discussionBoard d where d.id = :discussionId")
-    Optional<DiscussionBoardReply> findById(Long discussionId);
+    Optional<DiscussionBoardReply> findByDiscussionId(Long discussionId);
+
+    Optional<DiscussionBoardReply> findById(Long id);
 
     @Transactional
     @Modifying

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
 
@@ -13,10 +14,21 @@ import java.util.Optional;
 public interface DiscussionBoardRepository extends JpaRepository<DiscussionBoard, Long> {
 
     @Query(value = "select d from DiscussionBoard d join fetch d.user",
-            countQuery = "select count(d) from DiscussionBoard")
+            countQuery = "select count(d) from DiscussionBoard d")
     Page<DiscussionBoard> findAllWithFetchJoin(Pageable pageable);
 
     @Query(value = "select d from DiscussionBoard d join fetch d.user where d.id= :id")
-    Optional<DiscussionBoard> findById(Long id);
+    Optional<DiscussionBoard> findById(@Param("id") Long id);
 
+    @Query(value = "select d from DiscussionBoard d join fetch d.user where title like %:title%",
+            countQuery = "select count(d) from DiscussionBoard d")
+    Page<DiscussionBoard> findByTitleContaining(String title, Pageable pageable);
+
+    @Query(value = "select d from DiscussionBoard d join fetch d.user where content like %:content%",
+            countQuery = "select count(d) from DiscussionBoard d")
+    Page<DiscussionBoard> findByContentContaining(String content, Pageable pageable);
+
+    @Query(value = "select d from DiscussionBoard d join fetch d.user where title like %:search% or content like %:search%",
+            countQuery = "select count(d) from DiscussionBoard d")
+    Page<DiscussionBoard> findByAllContaining(String search, Pageable pageable);
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
@@ -10,7 +10,7 @@ import udodog.goGetterServer.model.entity.DiscussionBoard;
 import java.util.Optional;
 
 @Repository
-public interface DiscussonBoardRepository extends JpaRepository<DiscussionBoard, Long> {
+public interface DiscussionBoardRepository extends JpaRepository<DiscussionBoard, Long> {
 
     @Query(value = "select d from DiscussionBoard d join fetch d.user",
             countQuery = "select count(d) from DiscussionBoard")

--- a/src/main/java/udodog/goGetterServer/service/discussion/DiscussionReplyService.java
+++ b/src/main/java/udodog/goGetterServer/service/discussion/DiscussionReplyService.java
@@ -1,0 +1,98 @@
+package udodog.goGetterServer.service.discussion;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.Pagination;
+import udodog.goGetterServer.model.dto.request.discussion.DiscussionReplyEditRequest;
+import udodog.goGetterServer.model.dto.request.discussion.DiscussionReplyInsertRequest;
+import udodog.goGetterServer.model.dto.response.discussion.DiscussionReplyResponse;
+import udodog.goGetterServer.model.entity.DiscussionBoardReply;
+import udodog.goGetterServer.repository.DiscussionBoardReplyRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DiscussionReplyService {
+
+    private final DiscussionBoardReplyRepository replyRepository;
+
+    // 댓글 등록
+    public DefaultRes createReply(DiscussionReplyInsertRequest requestDto) {
+
+        if(requestDto == null) {
+            return DefaultRes.response(HttpStatus.OK.value(), "등록실패");
+        }else {
+           replyRepository.save(requestDto.toEntity(requestDto));
+           return DefaultRes.response(HttpStatus.OK.value(), "등록성공");
+        }
+    }
+
+    // 댓글 조회
+    public DefaultRes<List<DiscussionReplyResponse>> getBoardReplyList(Long discussionId, Pageable pageable) {
+
+        Page<DiscussionBoardReply> replyResponsesPage = replyRepository.findAllWithFetchJoin(discussionId, pageable);
+
+        if (replyResponsesPage.getTotalElements() == 0){
+            return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
+        }else {
+            return DefaultRes.response(HttpStatus.OK.value(), "조회성공", replyData(replyResponsesPage), new Pagination(replyResponsesPage));
+        }
+    }
+
+    private List<DiscussionReplyResponse> replyData(Page<DiscussionBoardReply> replyResponsesPage) {
+        return replyResponsesPage.stream()
+                .map(DiscussionReplyResponse::new)
+                .collect(Collectors.toList());
+    }
+
+
+    // 댓글 수정
+    public DefaultRes updateReply(DiscussionReplyEditRequest requestDto, Long discussionId) {
+
+        Optional<DiscussionBoardReply> boardReply = replyRepository.findByDiscussionId(discussionId);
+
+        if (boardReply.isEmpty()){
+            return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
+        }
+
+        if(!(boardReply.get().getUser().getId().equals(requestDto.getUserId()))){
+            return DefaultRes.response(HttpStatus.OK.value(), "수정실패");
+        }
+
+        DiscussionBoardReply replyBoard = boardReply.get().updateReply(requestDto);
+        DiscussionBoardReply saveReply  = replyRepository.save(replyBoard);
+
+        if(boardReply.get().getDiscussionBoard().getId().equals(saveReply.getDiscussionBoard().getId())){
+            return DefaultRes.response(HttpStatus.OK.value(), "수정성공");
+        }else {
+            return DefaultRes.response(HttpStatus.OK.value(), "수정실패");
+        }
+    }
+
+    // 댓글 삭제
+    public DefaultRes delete(Long id, Long userId) {
+        Optional<DiscussionBoardReply> deleteReply = replyRepository.findById(id);
+
+        if (deleteReply.isEmpty()){
+            return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
+        }
+
+        if(!(deleteReply.get().getUser().getId().equals(userId))){
+            return DefaultRes.response(HttpStatus.OK.value(), "삭제실패");
+        }
+
+        if(!(deleteReply.get().getId().equals(id))){
+            return DefaultRes.response(HttpStatus.OK.value(), "삭제실패");
+        }
+
+        replyRepository.deleteById(id);
+        return DefaultRes.response(HttpStatus.OK.value(), "삭제성공");
+    }
+}

--- a/src/main/java/udodog/goGetterServer/service/discussion/DiscussionReplyService.java
+++ b/src/main/java/udodog/goGetterServer/service/discussion/DiscussionReplyService.java
@@ -12,6 +12,7 @@ import udodog.goGetterServer.model.dto.request.discussion.DiscussionReplyInsertR
 import udodog.goGetterServer.model.dto.response.discussion.DiscussionReplyResponse;
 import udodog.goGetterServer.model.entity.DiscussionBoardReply;
 import udodog.goGetterServer.repository.DiscussionBoardReplyRepository;
+import udodog.goGetterServer.repository.DiscussionBoardReadhitRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class DiscussionReplyService {
 
     private final DiscussionBoardReplyRepository replyRepository;
+    private final DiscussionBoardReadhitRepository replyCountRepository;
 
     // 댓글 등록
     public DefaultRes createReply(DiscussionReplyInsertRequest requestDto) {
@@ -29,7 +31,7 @@ public class DiscussionReplyService {
         if(requestDto == null) {
             return DefaultRes.response(HttpStatus.OK.value(), "등록실패");
         }else {
-           replyRepository.save(requestDto.toEntity(requestDto));
+           DiscussionBoardReply saveReply = replyRepository.save(requestDto.toEntity(requestDto));
            return DefaultRes.response(HttpStatus.OK.value(), "등록성공");
         }
     }

--- a/src/main/java/udodog/goGetterServer/service/discussion/DiscussionService.java
+++ b/src/main/java/udodog/goGetterServer/service/discussion/DiscussionService.java
@@ -1,7 +1,6 @@
 package udodog.goGetterServer.service.discussion;
 
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -13,8 +12,8 @@ import udodog.goGetterServer.model.dto.request.discussion.DiscussionInsertReques
 import udodog.goGetterServer.model.dto.response.discussion.DiscussionDetailResponse;
 import udodog.goGetterServer.model.dto.response.discussion.DiscussionReseponseDto;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
-import udodog.goGetterServer.repository.DiscussonBoardReplyRepository;
-import udodog.goGetterServer.repository.DiscussonBoardRepository;
+import udodog.goGetterServer.repository.DiscussionBoardReplyRepository;
+import udodog.goGetterServer.repository.DiscussionBoardRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,8 +23,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DiscussionService {
 
-    private final DiscussonBoardRepository discussionBoardRepository;
-    private final DiscussonBoardReplyRepository replyRepository;
+    private final DiscussionBoardRepository discussionBoardRepository;
+    private final DiscussionBoardReplyRepository replyRepository;
 
     // 전체 목록 조회
     public DefaultRes<List<DiscussionReseponseDto>> getBoardList(Pageable pageable) {// 페이징 변수

--- a/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReadhitRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReadhitRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.FilterType;
 import udodog.goGetterServer.config.JpaAuditingConfig;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
 import udodog.goGetterServer.model.entity.DiscussionBoardReadhit;
+import udodog.goGetterServer.model.entity.DiscussionBoardReply;
 import udodog.goGetterServer.model.entity.User;
 import udodog.goGetterServer.model.enumclass.UserGrade;
 
@@ -28,7 +29,10 @@ class DiscussonBoardReadhitRepositoryTest {
     private DiscussionBoardRepository discussonBoardRepository;
 
     @Autowired
-    private DiscussionBoardReadhitRepository discussonBoardReadhitRepository;
+    private DiscussionBoardReplyRepository discussionBoardReplyRepository;
+
+    @Autowired
+    private DiscussionBoardReadhitRepository discussionReplyCountRepository;
 
     @Test
     void saveDiscussiontReadhit(){
@@ -51,17 +55,25 @@ class DiscussonBoardReadhitRepositoryTest {
                 .content("토론 게시판 테스트 내용 입니다.")
                 .build();
 
-        DiscussionBoard saveDiscussion = discussonBoardRepository.save(discussionBoard);
+        DiscussionBoard saveDiscussionBoard = discussonBoardRepository.save(discussionBoard);
 
-        DiscussionBoardReadhit discussionBoardReadhit = DiscussionBoardReadhit.builder()
-                .discussionBoard(saveDiscussion)
+        DiscussionBoardReply discussionBoardReply = DiscussionBoardReply.builder()
+                .discussionBoard(saveDiscussionBoard)
+                .user(saveUser)
+                .content("토론게시판 댓글 테스트 내용 입니다.")
+                .build();
+
+        DiscussionBoardReply saveDiscussionBoardReply = discussionBoardReplyRepository.save(discussionBoardReply);
+
+        DiscussionBoardReadhit discussionBoardCount = DiscussionBoardReadhit.builder()
+                .discussionBoard(saveDiscussionBoard)
                 .count(1)
                 .build();
 
         //when
-        DiscussionBoardReadhit saveDiscussionReadhit = discussonBoardReadhitRepository.save(discussionBoardReadhit);
+        DiscussionBoardReadhit savediscussionBoardCount = discussionReplyCountRepository.save(discussionBoardCount);
 
         //then
-        assertThat(discussionBoardReadhit).isEqualTo(saveDiscussionReadhit);
+        assertThat(discussionBoardCount).isEqualTo(savediscussionBoardCount);
     }
 }

--- a/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReadhitRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReadhitRepositoryTest.java
@@ -25,10 +25,10 @@ class DiscussonBoardReadhitRepositoryTest {
     private UserRepository userRepository;
 
     @Autowired
-    private DiscussonBoardRepository discussonBoardRepository;
+    private DiscussionBoardRepository discussonBoardRepository;
 
     @Autowired
-    private DiscussonBoardReadhitRepository discussonBoardReadhitRepository;
+    private DiscussionBoardReadhitRepository discussonBoardReadhitRepository;
 
     @Test
     void saveDiscussiontReadhit(){

--- a/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReplyRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/DiscussonBoardReplyRepositoryTest.java
@@ -25,10 +25,10 @@ class DiscussonBoardReplyRepositoryTest {
     private UserRepository userRepository;
 
     @Autowired
-    private DiscussonBoardRepository discussonBoardRepository;
+    private DiscussionBoardRepository discussonBoardRepository;
 
     @Autowired
-    private DiscussonBoardReplyRepository discussonBoardReplyRepository;
+    private DiscussionBoardReplyRepository discussonBoardReplyRepository;
 
     @Test
     void saveDicussionReply(){

--- a/src/test/java/udodog/goGetterServer/repository/DiscussonBoardRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/DiscussonBoardRepositoryTest.java
@@ -24,7 +24,7 @@ class DiscussonBoardRepositoryTest {
     private UserRepository userRepository;
 
     @Autowired
-    private DiscussonBoardRepository discussonBoardRepository;
+    private DiscussionBoardRepository discussonBoardRepository;
 
     @Test
     void saveDicussion(){


### PR DESCRIPTION
## 작업 사항
- 토론 게시판 전체 목록 조회 API 구현
- 토론 게시판 상세보기 API 구현
- 토론 게시판 글 등록 API 구현
- 토론 게시판 글 수정 API 구현
- 토론 게시판 글 삭제 API 구현
- 토론 게시판 댓글 목록 조회 API 구현
- 토론 게시판 댓글 등록 API 구현
- 토론 게시판 댓글 수정 API 구현
- 토론 게시판 댓글 삭제 API 구현
- 토론 게시판 제목으로 검색 API 구현
- 토론 게시판 내용으로 검색 API 구현
- 토론 게시판 제목 + 내용으로 검색 API 구현

## 요약
- 토론 게시판 전체 목록을 조회할 수 있고 제목을 클릭시 상세보기가 가능합니다.
- 토론 게시판 전체 목록에서 글 등록을 할 수 있습니다.
- 상세 페이지에서 글수정, 글삭제를 할 수 있습니다.
- 상세 페이지 내에서 댓글 조회, 등록, 수정, 삭제를 할 수 있습니다.
- 전체 목록에서 제목, 내용, 제목 + 내용으로 검색 할 수 있습니다.

## 첨부

## 이슈
issued : #27, #33, #44, #57, #58,  #63, #64, #73, #76, #78