### PR TITLE
[Event Create] 이벤트 등록 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
@@ -1,0 +1,43 @@
+package udodog.goGetterServer.controller.api.event;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import udodog.goGetterServer.model.converter.event.EventConverter;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.service.event.EventService;
+
+import javax.validation.Valid;
+
+@Api(tags = {"이벤트 관련 API"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class EventController {
+
+    private final EventService eventService;
+
+    private final EventConverter eventConverter;
+
+    @ApiOperation(value = "이벤트 등록 API",notes = "관리자가 이벤트 등록시 사용되는 API 입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 등록성공")
+    })
+    @PostMapping("/admin/events")
+    public ResponseEntity<EntityModel<DefaultRes>> eventCreate(
+            @ApiParam(value = "필수 : title, content, start_data, end_data" +
+                    "선택 : img_url")
+            @Valid @RequestBody EventCreateRequestDto request
+            ){
+        return new ResponseEntity<>(eventConverter.toModel(eventService.eventCreate(request)), HttpStatus.OK);
+    }
+
+
+}

--- a/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
@@ -1,0 +1,21 @@
+package udodog.goGetterServer.model.converter.event;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+import udodog.goGetterServer.controller.api.event.EventController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class EventConverter implements RepresentationModelAssembler<DefaultRes, EntityModel<DefaultRes>> {
+
+    @Override
+    public EntityModel<DefaultRes> toModel(DefaultRes entity) {
+        return EntityModel.of(entity,
+                linkTo(methodOn(EventController.class).eventCreate(null)).withRel("event-create"));
+    }
+
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/request/event/EventCreateRequestDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/event/EventCreateRequestDto.java
@@ -1,0 +1,44 @@
+package udodog.goGetterServer.model.dto.request.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import udodog.goGetterServer.model.entity.Event;
+
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.NotEmpty;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventCreateRequestDto {
+
+    @NotEmpty
+    private String title;
+
+    @NotEmpty
+    private String content;
+
+    @FutureOrPresent
+    private LocalDate startDate;
+
+    @FutureOrPresent
+    private LocalDate endDate;
+
+    private String imgUrl;
+
+    @Builder
+    public Event toEntity(){
+
+        return Event.builder()
+                .title(title)
+                .content(content)
+                .startDate(startDate)
+                .endDate(endDate)
+                .imgUrl(imgUrl)
+                .build();
+
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/entity/Event.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/Event.java
@@ -23,18 +23,18 @@ public class Event {
 
     private String content;
 
-    private LocalDate start_date;
+    private LocalDate startDate;
 
-    private LocalDate end_date;
+    private LocalDate endDate;
 
     private String imgUrl;
 
     @Builder
-    public Event(String title, String content, LocalDate start_date, LocalDate end_date, String imgUrl) {
+    public Event(String title, String content, LocalDate startDate, LocalDate endDate, String imgUrl) {
         this.title = title;
         this.content = content;
-        this.start_date = start_date;
-        this.end_date = end_date;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/udodog/goGetterServer/service/event/EventService.java
+++ b/src/main/java/udodog/goGetterServer/service/event/EventService.java
@@ -1,0 +1,20 @@
+package udodog.goGetterServer.service.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.repository.EventRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public DefaultRes eventCreate(EventCreateRequestDto request){
+        eventRepository.save(request.toEntity());
+        return DefaultRes.response(HttpStatus.OK.value(), "등록성공");
+    }
+}

--- a/src/test/java/udodog/goGetterServer/controller/api/event/EventControllerTest.java
+++ b/src/test/java/udodog/goGetterServer/controller/api/event/EventControllerTest.java
@@ -1,0 +1,47 @@
+package udodog.goGetterServer.controller.api.event;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import udodog.goGetterServer.config.WebMvcConfig;
+import udodog.goGetterServer.model.converter.event.EventConverter;
+import udodog.goGetterServer.service.event.EventService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(EventController.class)
+public class EventControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private EventService eventService;
+
+    @MockBean
+    private EventConverter eventConverter;
+
+    @MockBean
+    private WebMvcConfig webMvcConfig;
+
+    @Test
+    public void 이벤트_등록() throws Exception {
+
+        mvc.perform(post("/api/admin/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"content\": \"20 % 할인 쿠폰 지급\",\n" +
+                        "  \"end_date\": \"2021-07-01\",\n" +
+                        "  \"start_date\": \"2021-07-15\",\n" +
+                        "  \"title\": \"신규 가입 등록 이벤트\"\n" +
+                        "}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/udodog/goGetterServer/repository/EventRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/EventRepositoryTest.java
@@ -30,8 +30,8 @@ class EventRepositoryTest {
         Event event = Event.builder()
                 .title("서비스 오픈 기념")
                 .content("안녕하세요")
-                .start_date(LocalDate.of(2021,06,16))
-                .end_date(LocalDate.of(2021,07,16))
+                .startDate(LocalDate.of(2021,06,16))
+                .endDate(LocalDate.of(2021,07,16))
                 .build();
 
         //when

--- a/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
+++ b/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
@@ -1,0 +1,55 @@
+package udodog.goGetterServer.service.event;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.model.entity.Event;
+import udodog.goGetterServer.repository.EventRepository;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+@Slf4j
+public class EventServiceTest {
+
+    @InjectMocks
+    EventService eventService;
+
+    @Mock
+    EventRepository eventRepository;
+
+    @Test
+    public void 이벤트_생성(){
+
+        //given
+        String title = "신규 회원 등록 이벤트";
+        String content = "20% 할인 쿠폰 지급";
+        LocalDate startData = LocalDate.of(2021,7,1);
+        LocalDate endDate = LocalDate.of(2021,7,15);
+        String imgUrl = null;
+
+        EventCreateRequestDto eventCreateRequestDto = new EventCreateRequestDto(title, content, startData, endDate, imgUrl);
+
+        Event mockEvent = eventCreateRequestDto.toEntity();
+
+        //when
+        given(eventRepository.save(any())).willReturn(mockEvent);
+        DefaultRes defaultRes = eventService.eventCreate(eventCreateRequestDto);
+
+        //then
+        assertThat(defaultRes.getMessage()).isEqualTo("등록성공");
+
+    }
+
+
+}


### PR DESCRIPTION
### 작업 사항

#### <완료 목록>

- 이벤트 등록 API 구현

#### <진행중인 목록>

- 진행중인 이벤트 전체 조회 API 구현
- 진행중인 이벤트 상세 조회 API 구현

### 요약

- "관리자는 새로운 이벤트를 등록할 수 있다 " 요구사항 API 구현
- 관리자가 아닌 클라이언트는 API 요청 불가
- 이벤트 기간은 현재 기준으로 이후 날짜만 설정 가능 (유효성 처리)
- 컨트롤러, 서비스, 레파지토리 계층 테스트 코드 작성

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈

 issued : #79 