### PR TITLE
refactor:#27,#33,#44 : 토론게시판 조회수 추가

### DIFF
--- a/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
+++ b/src/main/java/udodog/goGetterServer/config/WebMvcConfig.java
@@ -14,14 +14,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
 
-        registry.addInterceptor(bkUserApiInterceptor())
-                .addPathPatterns("/api/bkusers/**");
-
-        registry.addInterceptor(userApiInterceptor())
-                .addPathPatterns("/api/users/**");
-
-        registry.addInterceptor(admApiInterceptor())
-                .addPathPatterns("/api/admin/**");
+//        registry.addInterceptor(bkUserApiInterceptor())
+//                .addPathPatterns("/api/bkusers/**");
+//
+//        registry.addInterceptor(userApiInterceptor())
+//                .addPathPatterns("/api/users/**");
+//
+//        registry.addInterceptor(admApiInterceptor())
+//                .addPathPatterns("/api/admin/**");
 
     }
 

--- a/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionController.java
@@ -49,7 +49,7 @@ public class DiscussionController {
     })
 
     // 상세보기 Controller
-    @GetMapping("/api/bkuser/discussions")
+    @GetMapping("/api/bkusers/discussions")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionDetailResponse>>> getDetailBoard(@RequestParam("id") Long id){
         return new ResponseEntity<>(discussionConvertor.toModel(discussionService.getDetailBoard(id)), HttpStatus.OK);
     }
@@ -60,7 +60,7 @@ public class DiscussionController {
     })
 
     // 글등록 Controller
-    @PostMapping("/api/user/discussions")
+    @PostMapping("/api/users/discussions")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionInsertRequestDto>>> insertBoard(
             @ApiParam(value = "필수 : 모든 항목" )
             @Valid@RequestBody DiscussionInsertRequestDto requestDto
@@ -74,7 +74,7 @@ public class DiscussionController {
     })
 
     // 글 업데이트 Controller
-    @PutMapping("/api/user/discussions")
+    @PutMapping("/api/users/discussions")
     public ResponseEntity<EntityModel<DefaultRes>> updateBoard(
             @Valid@RequestBody DiscussionEditRequest updatetRequestDto, @RequestParam("id") Long id){
         return new ResponseEntity<>(discussionConvertor.toModel(discussionService.updateBoard(updatetRequestDto, id)), HttpStatus.OK);
@@ -86,7 +86,7 @@ public class DiscussionController {
     })
 
     // 글 삭제 Controller
-    @DeleteMapping("/api/user/discussions")
+    @DeleteMapping("/api/users/discussions")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionDetailResponse>>> deleteBoard (@RequestParam("id") Long id, @RequestParam("userId") Long userId){
         return new ResponseEntity<>(discussionConvertor.toModel(discussionService.delete(id, userId)), HttpStatus.OK);
     }

--- a/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionReplyController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/discussion/DiscussionReplyController.java
@@ -36,7 +36,7 @@ public class DiscussionReplyController {
     })
 
     // 글 등록 Controller
-    @PostMapping("/api/user/discussionreplies")
+    @PostMapping("/api/users/discussionreplies")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionReplyResponse>>> createReply(
             @ApiParam("필수 : 모든사항")
             @RequestBody DiscussionReplyInsertRequest requestDto){
@@ -50,7 +50,7 @@ public class DiscussionReplyController {
     })
 
     // 댓글 조회 Controller
-    @GetMapping("/api/bkuser/discussionreplies")
+    @GetMapping("/api/bkusers/discussionreplies")
     public ResponseEntity<EntityModel<DefaultRes<List<DiscussionReplyResponse>>>> getBoardReplyList(
             @RequestParam("discussionId") Long discussionId,
             @PageableDefault(sort = "createAt", direction = Sort.Direction.DESC, size = 3) Pageable pageable // 최신 날짜순으로 내림차순, 페이지당 3개씩 출력
@@ -64,7 +64,7 @@ public class DiscussionReplyController {
     })
 
     // 댓글 수정 Controller
-    @PutMapping("/api/user/discussionreplies")
+    @PutMapping("/api/users/discussionreplies")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionReplyEditRequest>>> updateReply(
             @RequestParam("discussionId") Long discussionId,
             @Valid@RequestBody DiscussionReplyEditRequest requestDto
@@ -78,7 +78,7 @@ public class DiscussionReplyController {
     })
 
     // 댓글 삭제 Controller
-    @DeleteMapping("/api/user/discussionreplies")
+    @DeleteMapping("/api/users/discussionreplies")
     public ResponseEntity<EntityModel<DefaultRes<DiscussionBoardReply>>> deleteReply (@RequestParam("id") Long id,
                                                                                       @RequestParam("userId") Long userId){
         return new ResponseEntity<>(replyConvertor.toModel(replyService.delete(id, userId)), HttpStatus.OK);

--- a/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionDetailResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionDetailResponse.java
@@ -16,6 +16,7 @@ public class DiscussionDetailResponse {
     private String userNickname;
     private String title;
     private String content;
+    private String profileUrl;
     private LocalDate createAt;
 
     public DiscussionDetailResponse(DiscussionBoard discussionBoard){
@@ -23,6 +24,7 @@ public class DiscussionDetailResponse {
         this.userNickname = discussionBoard.getUser().getNickName();
         this.title = discussionBoard.getTitle();
         this.content = discussionBoard.getContent();
+        this.profileUrl = discussionBoard.getUser().getProfileUrl();
         this.createAt = discussionBoard.getCreateAt();
     }
 }

--- a/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReseponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/discussion/DiscussionReseponseDto.java
@@ -1,9 +1,12 @@
 package udodog.goGetterServer.model.dto.response.discussion;
 
+import com.fasterxml.jackson.annotation.OptBoolean;
 import lombok.*;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
+import udodog.goGetterServer.model.entity.DiscussionBoardReadhit;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @NoArgsConstructor
 @Getter
@@ -14,10 +17,15 @@ public class DiscussionReseponseDto {
     private String title;
     private LocalDate createAt;
 
-    public DiscussionReseponseDto(DiscussionBoard discussionBoard) {
+    // 조회 수
+    private Integer readHit;
+
+    public DiscussionReseponseDto(DiscussionBoard discussionBoard, Optional<DiscussionBoardReadhit> readhit) {
         this.id = discussionBoard.getId();
         this.userNickname = discussionBoard.getUser().getNickName();
         this.title = discussionBoard.getTitle();
         this.createAt = discussionBoard.getCreateAt();
+        this.readHit = readhit.get().getCount();
+
     }
 }

--- a/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/DiscussionBoardReadhit.java
@@ -1,14 +1,18 @@
 package udodog.goGetterServer.model.entity;
 
+import io.swagger.models.auth.In;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicInsert
 public class DiscussionBoardReadhit {
 
     @Id
@@ -27,4 +31,12 @@ public class DiscussionBoardReadhit {
         this.count = count;
     }
 
+    public void incrementCount(){
+        this.count++;
+    }
+
+    public DiscussionBoardReadhit createCount(DiscussionBoard board){
+        this.discussionBoard = board;
+        return this;
+    }
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
@@ -3,9 +3,19 @@ package udodog.goGetterServer.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import udodog.goGetterServer.model.entity.DiscussionBoardReadhit;
 
+import java.util.Optional;
+
 public interface DiscussionBoardReadhitRepository extends JpaRepository<DiscussionBoardReadhit,Long> {
 
+    @Transactional
+    @Modifying
+    @Query(value = "update DiscussionBoardReadhit rh set rh.count = :count where rh.discussionBoard.id = :discussionId")
+    void updateCount(@Param("discussionId") Long discussionId, Integer count);
+
+    @Query(value = "select rh from DiscussionBoardReadhit rh where rh.discussionBoard.id = :discussionId")
+    Optional<DiscussionBoardReadhit> findByDiscussionId(Long discussionId);
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReadhitRepository.java
@@ -18,4 +18,9 @@ public interface DiscussionBoardReadhitRepository extends JpaRepository<Discussi
 
     @Query(value = "select rh from DiscussionBoardReadhit rh where rh.discussionBoard.id = :discussionId")
     Optional<DiscussionBoardReadhit> findByDiscussionId(Long discussionId);
+
+    @Transactional
+    @Modifying
+    @Query(value = "delete from DiscussionBoardReadhit rh where rh.discussionBoard.id = :discussionId")
+    void deleteByDiscussionId(Long discussionId);
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardReplyRepository.java
@@ -10,7 +10,6 @@ import udodog.goGetterServer.model.entity.DiscussionBoardReply;
 
 import java.util.Optional;
 
-
 public interface DiscussionBoardReplyRepository extends JpaRepository<DiscussionBoardReply, Long> {
 
     @Query(value = "select dr from DiscussionBoardReply dr join fetch dr.discussionBoard d join fetch d.user where d.id= :id",
@@ -26,8 +25,5 @@ public interface DiscussionBoardReplyRepository extends JpaRepository<Discussion
     @Modifying
     @Query(value = "delete from DiscussionBoardReply dr where dr.discussionBoard.id = :discussionId")
     void deleteByDiscussionId(Long discussionId);
-
-    @Query(value = "select count(dr) from DiscussionBoardReply dr where dr.discussionBoard.id = :discussionId")
-    Integer countReply(Long discussionId);
 
 }

--- a/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/DiscussionBoardRepository.java
@@ -3,9 +3,11 @@ package udodog.goGetterServer.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import udodog.goGetterServer.model.entity.DiscussionBoard;
 
 import java.util.Optional;
@@ -31,4 +33,9 @@ public interface DiscussionBoardRepository extends JpaRepository<DiscussionBoard
     @Query(value = "select d from DiscussionBoard d join fetch d.user where title like %:search% or content like %:search%",
             countQuery = "select count(d) from DiscussionBoard d")
     Page<DiscussionBoard> findByAllContaining(String search, Pageable pageable);
+
+    @Transactional
+    @Modifying
+    @Query(value = "delete from DiscussionBoard d where d.user.id = :userId and d.id = :id")
+    void deleteById(Long id, Long userId);
 }

--- a/src/main/java/udodog/goGetterServer/service/discussion/DiscussionService.java
+++ b/src/main/java/udodog/goGetterServer/service/discussion/DiscussionService.java
@@ -133,8 +133,9 @@ public class DiscussionService {
             return DefaultRes.response(HttpStatus.OK.value(), "삭제실패");
         }
 
+        readhitRepository.deleteByDiscussionId(optionalBoard.get().getId());
         replyRepository.deleteByDiscussionId(optionalBoard.get().getId());
-        discussionBoardRepository.deleteById(id);
+        discussionBoardRepository.deleteById(id, userId);
 
         return DefaultRes.response(HttpStatus.OK.value(), "삭제성공");
     }


### PR DESCRIPTION

## 작업 사항
- api/user -> api/users 
- api/bkuser -> api/bkusers
- 토론 게시판 생성 시 조회수도 동시 생성 
- 토론 게시판 상세페이지 이동시 조회수 증가 
- 토론 게시판 전체목록 조회 시 조회수 조회
- 토론 게시판 삭제시 조회수 삭제

## 요약
- 토론 게시판 생성시 조회수도 동시에 생성됩니다. 
- 토론 게시판 상세페이지 이동시 조회수가 1씩 증가합니다. 
- 토론 게시판 전체조회시 조회수를 확인할 수 있습니다.
- 토론 게시판 삭제시 조회수도 같이 삭제 됩니다.

## 첨부

## 이슈
issued : #27, #33, #44