### PR TITLE
[End-Events-all-find] 종료된 이벤트 전체 조회 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import udodog.goGetterServer.model.converter.event.EventConverter;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.service.event.EventService;
 
 import javax.validation.Valid;
@@ -46,10 +46,20 @@ public class EventController {
             @ApiResponse(code=200, message = "1. 조회성공\n 2. 데이터없음")
     })
     @GetMapping("/events")
-    public ResponseEntity<EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>>> progressEventFindAll(
+    public ResponseEntity<EntityModel<DefaultRes<Page<EventsResponseDto>>>> progressEventFindAll(
             @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC, size = 12) Pageable pageable
     ){
         return new ResponseEntity<>(eventConverter.toModel(eventService.progressEventFindAll(pageable)), HttpStatus.OK);
     }
 
+    @ApiOperation(value = "종료된 이벤트 전체 조회 API",notes = "종료된 이벤트들을 최신 순으로 조회 합니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 조회성공\n 2. 데이터없음")
+    })
+    @GetMapping("/end-events")
+    public ResponseEntity<EntityModel<DefaultRes<Page<EventsResponseDto>>>> endEventFindAll(
+            @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC, size = 12) Pageable pageable
+    ){
+        return new ResponseEntity<>(eventConverter.toModel(eventService.endEventFindAll(pageable)), HttpStatus.OK);
+    }
 }

--- a/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
@@ -6,19 +6,21 @@ import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 import udodog.goGetterServer.controller.api.event.EventController;
 import udodog.goGetterServer.model.dto.DefaultRes;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class EventConverter implements RepresentationModelAssembler<DefaultRes<Page<ProgressEventsResponseDto>>, EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>>> {
+public class EventConverter implements RepresentationModelAssembler<DefaultRes<Page<EventsResponseDto>>, EntityModel<DefaultRes<Page<EventsResponseDto>>>> {
 
     @Override
-    public EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>> toModel(DefaultRes<Page<ProgressEventsResponseDto>> entity) {
+    public EntityModel<DefaultRes<Page<EventsResponseDto>>> toModel(DefaultRes<Page<EventsResponseDto>> entity) {
         return EntityModel.of(entity,
                 linkTo(methodOn(EventController.class).eventCreate(null)).withRel("event-create"),
-                linkTo(methodOn(EventController.class).progressEventFindAll(null)).withRel("progressEvent-Find-All"));
+                linkTo(methodOn(EventController.class).progressEventFindAll(null)).withRel("progressEvent-Find-All"),
+                linkTo(methodOn(EventController.class).endEventFindAll(null)).withRel("endEvent-Find-All"));
+
     }
 
 }

--- a/src/main/java/udodog/goGetterServer/model/dto/response/event/EventsResponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/event/EventsResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 
 @Getter
-public class ProgressEventsResponseDto {
+public class EventsResponseDto {
 
     private Long id;
 
@@ -15,7 +15,7 @@ public class ProgressEventsResponseDto {
 
     private LocalDate endDate;
 
-    public ProgressEventsResponseDto(Long id, String title, LocalDate startDate, LocalDate endDate) {
+    public EventsResponseDto(Long id, String title, LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.title = title;
         this.startDate = startDate;

--- a/src/main/java/udodog/goGetterServer/repository/querydsl/EventQueryRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/querydsl/EventQueryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,16 +20,35 @@ public class EventQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<ProgressEventsResponseDto> progressEventFindAll(Pageable pageable){
+    public Page<EventsResponseDto> progressEventFindAll(Pageable pageable){
 
-        List<ProgressEventsResponseDto> eventList = queryFactory
-                .select(Projections.constructor(ProgressEventsResponseDto.class,
+        List<EventsResponseDto> eventList = queryFactory
+                .select(Projections.constructor(EventsResponseDto.class,
                         event.id.as("eventId"),
                         event.title,
                         event.startDate,
                         event.endDate))
                 .from(event)
                 .where(event.endDate.after(LocalDate.now().minusDays(1)))
+                .fetch();
+
+        int start = (int)pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), eventList.size());
+
+        return new PageImpl<>(eventList.subList(start, end), pageable, eventList.size());
+
+    }
+
+    public Page<EventsResponseDto> endEventFindAll(Pageable pageable){
+
+        List<EventsResponseDto> eventList = queryFactory
+                .select(Projections.constructor(EventsResponseDto.class,
+                        event.id.as("eventId"),
+                        event.title,
+                        event.startDate,
+                        event.endDate))
+                .from(event)
+                .where(event.endDate.before(LocalDate.now().minusDays(1)))
                 .fetch();
 
         int start = (int)pageable.getOffset();

--- a/src/main/java/udodog/goGetterServer/service/event/EventService.java
+++ b/src/main/java/udodog/goGetterServer/service/event/EventService.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.repository.EventRepository;
 import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
 
@@ -25,9 +25,19 @@ public class EventService {
         return DefaultRes.response(HttpStatus.OK.value(), "등록성공");
     }
 
-    public DefaultRes<Page<ProgressEventsResponseDto>> progressEventFindAll(Pageable pageable){
+    public DefaultRes<Page<EventsResponseDto>> progressEventFindAll(Pageable pageable){
 
-        Page<ProgressEventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageable);
+        Page<EventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageable);
+
+        if(result.getTotalElements() == 0){
+            return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
+        }
+        return DefaultRes.response(HttpStatus.OK.value(), "조회성공", result);
+    }
+
+    public DefaultRes<Page<EventsResponseDto>> endEventFindAll(Pageable pageable){
+
+        Page<EventsResponseDto> result = eventQueryRepository.endEventFindAll(pageable);
 
         if(result.getTotalElements() == 0){
             return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");

--- a/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit4.SpringRunner;
 import udodog.goGetterServer.config.JpaAuditingConfig;
 import udodog.goGetterServer.config.TestConfig;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 
 @RunWith(SpringRunner.class)
@@ -36,7 +36,7 @@ public class EventQueryRepositoryTest {
     public void 진행중인_이벤트_전체조회(){
         PageRequest pageRequest = PageRequest.of(0, 12, Sort.by("startDate").descending());
 
-        Page<ProgressEventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageRequest);
+        Page<EventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageRequest);
 
         result.stream()
                 .forEach(value -> log.info("title = {}, startDate = {}. endDate = {} ", value.getTitle(), value.getStartDate(), value.getEndDate()));

--- a/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
+++ b/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit4.SpringRunner;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.model.entity.Event;
 import udodog.goGetterServer.repository.EventRepository;
 import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
@@ -67,7 +67,7 @@ public class EventServiceTest {
 
         //given
 
-        List<ProgressEventsResponseDto> eventList = new ArrayList<>();
+        List<EventsResponseDto> eventList = new ArrayList<>();
 
         Long id = 1L;
         String title = "신규 회원 등록 이벤트";
@@ -83,18 +83,18 @@ public class EventServiceTest {
         LocalDate endDate2 = LocalDate.of(2021,7,20);
         String imgUrl2 = null;
 
-        ProgressEventsResponseDto event1 = new ProgressEventsResponseDto(id, title, startData, endDate);
-        ProgressEventsResponseDto event2 = new ProgressEventsResponseDto(id2, title, startData, endDate);
+        EventsResponseDto event1 = new EventsResponseDto(id, title, startData, endDate);
+        EventsResponseDto event2 = new EventsResponseDto(id2, title, startData, endDate);
 
         eventList.add(event1);
         eventList.add(event2);
 
         //when
         PageRequest pageRequest = PageRequest.of(0, 12, Sort.by("startDate").descending());
-        Page<ProgressEventsResponseDto> eventPage = new PageImpl<>(eventList, pageRequest, 2);
+        Page<EventsResponseDto> eventPage = new PageImpl<>(eventList, pageRequest, 2);
         given(eventQueryRepository.progressEventFindAll(pageRequest)).willReturn(eventPage);
 
-        DefaultRes<Page<ProgressEventsResponseDto>> result = eventService.progressEventFindAll(pageRequest);
+        DefaultRes<Page<EventsResponseDto>> result = eventService.progressEventFindAll(pageRequest);
 
         //then
         assertThat(result.getMessage()).isEqualTo("조회성공");


### PR DESCRIPTION
### 작업 사항

#### 완료 목록

- 이벤트 등록 API
- 진행 중인 이벤트 전체조회 API
- 종료된 이벤트 전체조회 API

#### 진행 중 목록

- 진행 중인 이벤트 상세조회 API
- 이벤트 수정 API
- 이벤트 삭제 API

### 요약

이벤트 종료 날짜가 현재 날짜보다 이전인 종료된 이벤트 데이터만 가져와 페이징 처리

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈

issued : #91 