### PR TITLE
[Events-detail-find] 진행중인 이벤트 상세조회 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import udodog.goGetterServer.model.converter.event.EventConverter;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.model.dto.response.event.DetailEventResponseDto;
 import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.service.event.EventService;
 
@@ -61,5 +62,16 @@ public class EventController {
             @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC, size = 12) Pageable pageable
     ){
         return new ResponseEntity<>(eventConverter.toModel(eventService.endEventFindAll(pageable)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "진행중인 이벤트 상세 조회 API",notes = "진행중인 이벤트를 상세 조회 합니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 조회성공\n 2. 데이터없음")
+    })
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<DefaultRes<DetailEventResponseDto>> eventDetailFind(
+            @PathVariable("eventId") Long eventId
+    ){
+        return new ResponseEntity<>(eventService.eventDetailFind(eventId), HttpStatus.OK);
     }
 }

--- a/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/event/EventController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import udodog.goGetterServer.model.converter.event.EventConverter;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.service.event.EventService;
 
 import javax.validation.Valid;
@@ -46,10 +46,20 @@ public class EventController {
             @ApiResponse(code=200, message = "1. 조회성공\n 2. 데이터없음")
     })
     @GetMapping("/events")
-    public ResponseEntity<EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>>> progressEventFindAll(
+    public ResponseEntity<EntityModel<DefaultRes<Page<EventsResponseDto>>>> progressEventFindAll(
             @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC, size = 12) Pageable pageable
     ){
         return new ResponseEntity<>(eventConverter.toModel(eventService.progressEventFindAll(pageable)), HttpStatus.OK);
     }
 
+    @ApiOperation(value = "종료된 이벤트 전체 조회 API",notes = "종료된 이벤트들을 최신 순으로 조회 합니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 조회성공\n 2. 데이터없음")
+    })
+    @GetMapping("/end-events")
+    public ResponseEntity<EntityModel<DefaultRes<Page<EventsResponseDto>>>> endEventFindAll(
+            @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC, size = 12) Pageable pageable
+    ){
+        return new ResponseEntity<>(eventConverter.toModel(eventService.endEventFindAll(pageable)), HttpStatus.OK);
+    }
 }

--- a/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
+++ b/src/main/java/udodog/goGetterServer/model/converter/event/EventConverter.java
@@ -6,19 +6,21 @@ import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 import udodog.goGetterServer.controller.api.event.EventController;
 import udodog.goGetterServer.model.dto.DefaultRes;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class EventConverter implements RepresentationModelAssembler<DefaultRes<Page<ProgressEventsResponseDto>>, EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>>> {
+public class EventConverter implements RepresentationModelAssembler<DefaultRes<Page<EventsResponseDto>>, EntityModel<DefaultRes<Page<EventsResponseDto>>>> {
 
     @Override
-    public EntityModel<DefaultRes<Page<ProgressEventsResponseDto>>> toModel(DefaultRes<Page<ProgressEventsResponseDto>> entity) {
+    public EntityModel<DefaultRes<Page<EventsResponseDto>>> toModel(DefaultRes<Page<EventsResponseDto>> entity) {
         return EntityModel.of(entity,
                 linkTo(methodOn(EventController.class).eventCreate(null)).withRel("event-create"),
-                linkTo(methodOn(EventController.class).progressEventFindAll(null)).withRel("progressEvent-Find-All"));
+                linkTo(methodOn(EventController.class).progressEventFindAll(null)).withRel("progressEvent-Find-All"),
+                linkTo(methodOn(EventController.class).endEventFindAll(null)).withRel("endEvent-Find-All"));
+
     }
 
 }

--- a/src/main/java/udodog/goGetterServer/model/dto/request/event/EventCreateRequestDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/event/EventCreateRequestDto.java
@@ -29,6 +29,8 @@ public class EventCreateRequestDto {
 
     private String imgUrl;
 
+    private Long couponBoxId;
+
     @Builder
     public Event toEntity(){
 
@@ -38,6 +40,7 @@ public class EventCreateRequestDto {
                 .startDate(startDate)
                 .endDate(endDate)
                 .imgUrl(imgUrl)
+                .couponBoxId(couponBoxId)
                 .build();
 
     }

--- a/src/main/java/udodog/goGetterServer/model/dto/response/event/DetailEventResponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/event/DetailEventResponseDto.java
@@ -1,0 +1,34 @@
+package udodog.goGetterServer.model.dto.response.event;
+
+import lombok.Getter;
+import udodog.goGetterServer.model.entity.Event;
+
+import java.time.LocalDate;
+
+@Getter
+public class DetailEventResponseDto {
+
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private String imgUrl;
+
+    private Long couponBoxId;
+
+    public DetailEventResponseDto(Event event) {
+        this.id = event.getId();
+        this.title = event.getTitle();
+        this.content = event.getContent();
+        this.startDate = event.getStartDate();
+        this.endDate = event.getEndDate();
+        this.imgUrl = event.getImgUrl();
+        this.couponBoxId = event.getCouponBoxId();
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/response/event/EventsResponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/event/EventsResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 
 @Getter
-public class ProgressEventsResponseDto {
+public class EventsResponseDto {
 
     private Long id;
 
@@ -15,7 +15,7 @@ public class ProgressEventsResponseDto {
 
     private LocalDate endDate;
 
-    public ProgressEventsResponseDto(Long id, String title, LocalDate startDate, LocalDate endDate) {
+    public EventsResponseDto(Long id, String title, LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.title = title;
         this.startDate = startDate;

--- a/src/main/java/udodog/goGetterServer/model/entity/Event.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/Event.java
@@ -1,5 +1,6 @@
 package udodog.goGetterServer.model.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import javax.persistence.Id;
 import java.time.LocalDate;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 @Entity
 public class Event {
@@ -29,12 +31,15 @@ public class Event {
 
     private String imgUrl;
 
+    private Long couponBoxId;
+
     @Builder
-    public Event(String title, String content, LocalDate startDate, LocalDate endDate, String imgUrl) {
+    public Event(String title, String content, LocalDate startDate, LocalDate endDate, String imgUrl, Long couponBoxId) {
         this.title = title;
         this.content = content;
         this.startDate = startDate;
         this.endDate = endDate;
         this.imgUrl = imgUrl;
+        this.couponBoxId = couponBoxId;
     }
 }

--- a/src/main/java/udodog/goGetterServer/repository/querydsl/EventQueryRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/querydsl/EventQueryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,16 +20,35 @@ public class EventQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<ProgressEventsResponseDto> progressEventFindAll(Pageable pageable){
+    public Page<EventsResponseDto> progressEventFindAll(Pageable pageable){
 
-        List<ProgressEventsResponseDto> eventList = queryFactory
-                .select(Projections.constructor(ProgressEventsResponseDto.class,
+        List<EventsResponseDto> eventList = queryFactory
+                .select(Projections.constructor(EventsResponseDto.class,
                         event.id.as("eventId"),
                         event.title,
                         event.startDate,
                         event.endDate))
                 .from(event)
                 .where(event.endDate.after(LocalDate.now().minusDays(1)))
+                .fetch();
+
+        int start = (int)pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), eventList.size());
+
+        return new PageImpl<>(eventList.subList(start, end), pageable, eventList.size());
+
+    }
+
+    public Page<EventsResponseDto> endEventFindAll(Pageable pageable){
+
+        List<EventsResponseDto> eventList = queryFactory
+                .select(Projections.constructor(EventsResponseDto.class,
+                        event.id.as("eventId"),
+                        event.title,
+                        event.startDate,
+                        event.endDate))
+                .from(event)
+                .where(event.endDate.before(LocalDate.now().minusDays(1)))
                 .fetch();
 
         int start = (int)pageable.getOffset();

--- a/src/main/java/udodog/goGetterServer/service/event/EventService.java
+++ b/src/main/java/udodog/goGetterServer/service/event/EventService.java
@@ -7,9 +7,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.model.dto.response.event.DetailEventResponseDto;
 import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
+import udodog.goGetterServer.model.entity.Event;
 import udodog.goGetterServer.repository.EventRepository;
 import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
+
+import java.util.Optional;
 
 
 @Service
@@ -43,5 +47,15 @@ public class EventService {
             return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
         }
         return DefaultRes.response(HttpStatus.OK.value(), "조회성공", result);
+    }
+
+    public DefaultRes<DetailEventResponseDto> eventDetailFind(Long eventId){
+
+        Optional<Event> optionalEvent = eventRepository.findById(eventId);
+
+        return optionalEvent
+                .map(event -> DefaultRes.response(HttpStatus.OK.value(), "조회성공", new DetailEventResponseDto(event)))
+                .orElseGet(() -> DefaultRes.response(HttpStatus.OK.value(), "데이터없음"));
+
     }
 }

--- a/src/main/java/udodog/goGetterServer/service/event/EventService.java
+++ b/src/main/java/udodog/goGetterServer/service/event/EventService.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.repository.EventRepository;
 import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
 
@@ -25,9 +25,19 @@ public class EventService {
         return DefaultRes.response(HttpStatus.OK.value(), "등록성공");
     }
 
-    public DefaultRes<Page<ProgressEventsResponseDto>> progressEventFindAll(Pageable pageable){
+    public DefaultRes<Page<EventsResponseDto>> progressEventFindAll(Pageable pageable){
 
-        Page<ProgressEventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageable);
+        Page<EventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageable);
+
+        if(result.getTotalElements() == 0){
+            return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
+        }
+        return DefaultRes.response(HttpStatus.OK.value(), "조회성공", result);
+    }
+
+    public DefaultRes<Page<EventsResponseDto>> endEventFindAll(Pageable pageable){
+
+        Page<EventsResponseDto> result = eventQueryRepository.endEventFindAll(pageable);
 
         if(result.getTotalElements() == 0){
             return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");

--- a/src/test/java/udodog/goGetterServer/controller/api/event/EventControllerTest.java
+++ b/src/test/java/udodog/goGetterServer/controller/api/event/EventControllerTest.java
@@ -39,8 +39,8 @@ public class EventControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\n" +
                         "  \"content\": \"20 % 할인 쿠폰 지급\",\n" +
-                        "  \"end_date\": \"2021-07-01\",\n" +
-                        "  \"start_date\": \"2021-07-15\",\n" +
+                        "  \"end_date\": \"2021-10-15\",\n" +
+                        "  \"start_date\": \"2021-10-20\",\n" +
                         "  \"title\": \"신규 가입 등록 이벤트\"\n" +
                         "}"))
                 .andExpect(status().isOk());
@@ -51,6 +51,14 @@ public class EventControllerTest {
 
         mvc.perform(get("/api/events")
                 .param("page", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 진행중인_이벤트_상세조회() throws Exception {
+
+        Long eventId = 9L;
+        mvc.perform(get("/api/events/{eventId}", eventId))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
@@ -41,7 +41,7 @@ public class EventQueryRepositoryTest {
         result.stream()
                 .forEach(value -> log.info("title = {}, startDate = {}. endDate = {} ", value.getTitle(), value.getStartDate(), value.getEndDate()));
 
-        Assertions.assertThat(result.getTotalElements()).isEqualTo(12);
+        Assertions.assertThat(result.get().count()).isEqualTo(12);
     }
 
 }

--- a/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
+++ b/src/test/java/udodog/goGetterServer/repository/querydsl/EventQueryRepositoryTest.java
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit4.SpringRunner;
 import udodog.goGetterServer.config.JpaAuditingConfig;
 import udodog.goGetterServer.config.TestConfig;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 
 
 @RunWith(SpringRunner.class)
@@ -36,7 +36,7 @@ public class EventQueryRepositoryTest {
     public void 진행중인_이벤트_전체조회(){
         PageRequest pageRequest = PageRequest.of(0, 12, Sort.by("startDate").descending());
 
-        Page<ProgressEventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageRequest);
+        Page<EventsResponseDto> result = eventQueryRepository.progressEventFindAll(pageRequest);
 
         result.stream()
                 .forEach(value -> log.info("title = {}, startDate = {}. endDate = {} ", value.getTitle(), value.getStartDate(), value.getEndDate()));

--- a/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
+++ b/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit4.SpringRunner;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
+import udodog.goGetterServer.model.dto.response.event.DetailEventResponseDto;
 import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.model.entity.Event;
 import udodog.goGetterServer.repository.EventRepository;
@@ -21,6 +22,7 @@ import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,8 +50,9 @@ public class EventServiceTest {
         LocalDate startData = LocalDate.of(2021,7,1);
         LocalDate endDate = LocalDate.of(2021,7,15);
         String imgUrl = null;
+        Long couponBoxId = null;
 
-        EventCreateRequestDto eventCreateRequestDto = new EventCreateRequestDto(title, content, startData, endDate, imgUrl);
+        EventCreateRequestDto eventCreateRequestDto = new EventCreateRequestDto(title, content, startData, endDate, imgUrl, couponBoxId);
 
         Event mockEvent = eventCreateRequestDto.toEntity();
 
@@ -101,5 +104,29 @@ public class EventServiceTest {
         assertThat(result.getData().getTotalElements()).isEqualTo(2);
     }
 
+    @Test
+    public void 진행중인_이벤트_상세조회(){
 
+        //given
+
+        Long id = 1L;
+        String title = "신규 회원 등록 이벤트";
+        String content = "20% 할인 쿠폰 지급";
+        LocalDate startData = LocalDate.of(2021,7,1);
+        LocalDate endDate = LocalDate.of(2021,7,15);
+        String imgUrl = null;
+        Long couponBoxId = 5L;
+
+        Event event = new Event(id, title, content, startData, endDate, imgUrl, couponBoxId);
+        given(eventRepository.findById(id)).willReturn(Optional.of(event));
+
+        //when
+        DefaultRes<DetailEventResponseDto> result = eventService.eventDetailFind(id);
+
+        //then
+        assertThat(result.getMessage()).isEqualTo("조회성공");
+        assertThat(result.getData().getId()).isEqualTo(id);
+        assertThat(result.getData().getTitle()).isEqualTo(title);
+        assertThat(result.getData().getCouponBoxId()).isEqualTo(5L);
+    }
 }

--- a/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
+++ b/src/test/java/udodog/goGetterServer/service/event/EventServiceTest.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit4.SpringRunner;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.request.event.EventCreateRequestDto;
-import udodog.goGetterServer.model.dto.response.event.ProgressEventsResponseDto;
+import udodog.goGetterServer.model.dto.response.event.EventsResponseDto;
 import udodog.goGetterServer.model.entity.Event;
 import udodog.goGetterServer.repository.EventRepository;
 import udodog.goGetterServer.repository.querydsl.EventQueryRepository;
@@ -67,7 +67,7 @@ public class EventServiceTest {
 
         //given
 
-        List<ProgressEventsResponseDto> eventList = new ArrayList<>();
+        List<EventsResponseDto> eventList = new ArrayList<>();
 
         Long id = 1L;
         String title = "신규 회원 등록 이벤트";
@@ -83,18 +83,18 @@ public class EventServiceTest {
         LocalDate endDate2 = LocalDate.of(2021,7,20);
         String imgUrl2 = null;
 
-        ProgressEventsResponseDto event1 = new ProgressEventsResponseDto(id, title, startData, endDate);
-        ProgressEventsResponseDto event2 = new ProgressEventsResponseDto(id2, title, startData, endDate);
+        EventsResponseDto event1 = new EventsResponseDto(id, title, startData, endDate);
+        EventsResponseDto event2 = new EventsResponseDto(id2, title, startData, endDate);
 
         eventList.add(event1);
         eventList.add(event2);
 
         //when
         PageRequest pageRequest = PageRequest.of(0, 12, Sort.by("startDate").descending());
-        Page<ProgressEventsResponseDto> eventPage = new PageImpl<>(eventList, pageRequest, 2);
+        Page<EventsResponseDto> eventPage = new PageImpl<>(eventList, pageRequest, 2);
         given(eventQueryRepository.progressEventFindAll(pageRequest)).willReturn(eventPage);
 
-        DefaultRes<Page<ProgressEventsResponseDto>> result = eventService.progressEventFindAll(pageRequest);
+        DefaultRes<Page<EventsResponseDto>> result = eventService.progressEventFindAll(pageRequest);
 
         //then
         assertThat(result.getMessage()).isEqualTo("조회성공");


### PR DESCRIPTION
### 작업 사항

#### 완료 목록

- 이벤트 등록 API
- 진행 중인 이벤트 전체조회 API
- 종료된 이벤트 전체조회 API
- 진행중인 이벤트 상세조회 API

#### 진행 중 목록

- 이벤트 수정 API
- 이벤트 삭제 API
- 
### 요약
클라이언트 요청시 event_id를 받으면 해당 id에 존재하는 데이터가 있으면 응답 DTO로 반환. 없을시 데이터 없음으로 반환
사용자가 해당 이벤트에 대한 쿠폰을 다운로드 받으려면 상세 조회시 응답 DTO로 coupon_box_id를 반환 받아야함.
event 테이블 컬럼 추가 -> coupon_box_id

### 첨부
작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
issued : #99 #93 