### PR TITLE
Refactor #140 : 독서 기록 게시판 URI 수정 및 Bug 수정

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/bookreport/BookReportController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/bookreport/BookReportController.java
@@ -34,7 +34,7 @@ public class BookReportController {
     @ApiResponses( value = { @ApiResponse( code=200, message = "1. 조회성공 \t\n 2. 데이터없음 \t\n 3. 토큰에러" )})
 
     // 전체 조회 관련 Method
-    @GetMapping("/api/book-reports")
+    @GetMapping("/api/bkusers/book-reports")
     public ResponseEntity<EntityModel<DefaultRes<Page<BookreportResponseDto>>>> totalBookReportFindAll(
             @PageableDefault( sort = "bookReportId", direction = Sort.Direction.DESC, size = 10 ) Pageable pageable ) {  // Index Value를 이용 최신 날짜순을 기준으로 내림차순으로 페이지당 10개씩 출력
 
@@ -50,7 +50,7 @@ public class BookReportController {
     })
 
     // 독서 기록 상세보기 관련 Method
-    @GetMapping("/api/book-reports/{bookReportId}")
+    @GetMapping("/api/bkusers/book-reports/{bookReportId}")
     public ResponseEntity<EntityModel<DefaultRes<BookReportDetailResponseDto>>> viewDetailBookReport(@PathVariable("bookReportId") Long bookReportId, @RequestParam("userId") Long userId) {
 
         return new ResponseEntity<>(bookReportConverter.toModel(bookreportService.viewDetailBookReport(bookReportId, userId)), HttpStatus.OK);
@@ -62,9 +62,9 @@ public class BookReportController {
     @ApiResponses(value = { @ApiResponse(code=200, message = "1.등록성공 \t\n 2.등록실패 \t\n 3. 토큰에러") })
 
     // 독서 기록 등록 관련 Mehotd
-    @PostMapping("/api/book-reports")
+    @PostMapping("/api/bkusers/book-reports")
     public ResponseEntity<EntityModel<DefaultRes<BookreportInsertRequestDto>>> insertReport (
-            @ApiParam( value = "필수 : 모든 항목" )
+            @ApiParam( value = "필수 : Tag를 제외한 모든 항목" )
             @Valid @RequestBody BookreportInsertRequestDto bookreportInsertRequestDto, @RequestParam ( "userId" ) Long userId ) {
 
         return new ResponseEntity<>(bookReportConverter.toModel(bookreportService.insertReport(bookreportInsertRequestDto, userId)), HttpStatus.OK);
@@ -74,7 +74,7 @@ public class BookReportController {
     @ApiResponses(value = { @ApiResponse( code = 200, message = "1.수정성공 \t\n 2.수정실패 \t\n 3.데이터없음 \t\n 4.토큰에러" )})
 
     // 수정 Method
-    @PatchMapping("/api/book-reports/{bookReportId}")
+    @PatchMapping("/api/bkusers/book-reports/{bookReportId}")
     public ResponseEntity<EntityModel<EntityModel<DefaultRes>>> updateBookReport (
             @Valid @RequestBody BookreportUpdateRequestDto updateRequestDto, @PathVariable("bookReportId") Long bookReportId, @RequestParam("userId") Long userId) {
 
@@ -82,7 +82,7 @@ public class BookReportController {
     } // updateBookReport() 끝
 
     // 삭제 Method
-    @DeleteMapping("/api/book-reports/{bookReportId}")
+    @DeleteMapping("/api/bkusers/book-reports/{bookReportId}")
     public ResponseEntity<EntityModel<DefaultRes<BookReportDetailResponseDto>>> deleteReport (@PathVariable("bookReportId") Long bookReportId, @RequestParam("userId") Long userId) {
 
         return new ResponseEntity<>(bookReportConverter.toModel(bookreportService.deleteReport(bookReportId, userId)), HttpStatus.OK);
@@ -93,7 +93,7 @@ public class BookReportController {
     // ##################################### 검색 기능 #####################################
 
     // 제목 검색
-    @GetMapping("/api/book-reports/search/{title-search}")
+    @GetMapping("/api/bkusers/book-reports/search/{title-search}")
     public ResponseEntity<EntityModel<DefaultRes<Page<BookreportResponseDto>>>> titleSearch ( @PathVariable("title-search") String title, @PageableDefault (sort = "bookReportId", direction = Sort.Direction.DESC, size = 10) Pageable pageable) {
 
         return new ResponseEntity<>(bookReportPagingConverter.toModel(bookreportService.titleSearch(title, pageable)), HttpStatus.OK);

--- a/src/main/java/udodog/goGetterServer/model/dto/request/bookreporttag/BookReportTagInsertRequestDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/bookreporttag/BookReportTagInsertRequestDto.java
@@ -14,7 +14,7 @@ public class BookReportTagInsertRequestDto {
 
     private String tagName;         // Tag 내용
     
-    public BookReportTag toEntiry(Optional<BookReport> bookReport, BookReportTagInsertRequestDto bookReportTagInsertRequestDto) {
+    public BookReportTag toEntity(Optional<BookReport> bookReport, BookReportTagInsertRequestDto bookReportTagInsertRequestDto) {
         
         return BookReportTag.builder()
                 .bookReport(bookReport.get())

--- a/src/main/java/udodog/goGetterServer/model/dto/response/bookreport/BookReportDetailResponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/bookreport/BookReportDetailResponseDto.java
@@ -1,29 +1,34 @@
 package udodog.goGetterServer.model.dto.response.bookreport;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import udodog.goGetterServer.model.entity.BookReport;
-import udodog.goGetterServer.model.entity.BookReportTag;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BookReportDetailResponseDto {
 
     private Long bookReportId;
+    private String userNickName;
     private String bookName;
     private String title;
     private String content;
-    private LocalDate createAt;
+    private LocalDateTime createAt;
     private String bookReportTag;
 
-    public BookReportDetailResponseDto (BookReport bookReport, BookReportTag bookReportTag) {
-        this.bookReportId = bookReport.getBookReportId();
-        this.bookName = bookReport.getBookName();
-        this.title = bookReport.getTitle();
-        this.content = bookReport.getContent();
-        this.createAt = bookReport.getCreatedAt();
-        this.bookReportTag = bookReportTag.getTagName();
+
+    public BookReportDetailResponseDto (Optional<BookReportDetailResponseDto> bookReportDetailResponseDto) {
+        this.bookReportId = bookReportDetailResponseDto.get().getBookReportId();
+        this.userNickName = bookReportDetailResponseDto.get().getUserNickName();
+        this.bookName = bookReportDetailResponseDto.get().getBookName();
+        this.title = bookReportDetailResponseDto.get().getTitle();
+        this.content = bookReportDetailResponseDto.get().getContent();
+        this.createAt = bookReportDetailResponseDto.get().getCreateAt();
+        this.bookReportTag = bookReportDetailResponseDto.get().getBookReportTag();
     } // 생성자 끝
 
 } // Class 끝

--- a/src/main/java/udodog/goGetterServer/model/dto/response/bookreport/BookreportResponseDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/bookreport/BookreportResponseDto.java
@@ -1,12 +1,10 @@
 package udodog.goGetterServer.model.dto.response.bookreport;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import udodog.goGetterServer.model.entity.BookReportTag;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -16,17 +14,18 @@ public class BookreportResponseDto {
     private String userNickname;                    // User Nickname
     private String bookName;                        // 책 제목
     private String title;                           // 독서 기록 글 제목
-    private LocalDate createAt;                     // 작성일
-    private String bookReportTag;                    // 태그 객체
+    private LocalDateTime createAt;                     // 작성일
+    private String bookReportTag;                    // 태그 내용
 
 
-    public BookreportResponseDto ( Long bookReportId, String userNickname, String bookName, String title, LocalDate createAt ) {
+    public BookreportResponseDto ( Long bookReportId, String userNickname, String bookName, String title, LocalDateTime createAt, String bookReportTag ) {
 
         this.bookReportId = bookReportId;
         this.userNickname = userNickname;
         this.bookName = bookName;
         this.title = title;
         this.createAt = createAt;
+        this.bookReportTag = bookReportTag;
 
     } // 생성자 끝
 

--- a/src/main/java/udodog/goGetterServer/model/entity/BookReport.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/BookReport.java
@@ -7,7 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -30,10 +30,10 @@ public class BookReport {
     private String content;
 
     @CreatedDate
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
 
     @Builder
-    public BookReport(User user, String title, String bookName, String content, LocalDate createdAt) {
+    public BookReport(User user, String title, String bookName, String content, LocalDateTime createdAt) {
         this.user = user;
         this.title = title;
         this.bookName = bookName;

--- a/src/main/java/udodog/goGetterServer/model/entity/BookReportTag.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/BookReportTag.java
@@ -3,6 +3,7 @@ package udodog.goGetterServer.model.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 
@@ -19,6 +20,7 @@ public class BookReportTag {
     @JoinColumn(name = "book_report_id")
     private BookReport bookReport;
 
+    @ColumnDefault(value = "")
     private String tagName;
 
     @Builder

--- a/src/main/java/udodog/goGetterServer/service/bookreport/BookreportService.java
+++ b/src/main/java/udodog/goGetterServer/service/bookreport/BookreportService.java
@@ -69,24 +69,22 @@ public class BookreportService {
     // 독서 기록 상세 조회 Method
     public DefaultRes<BookReportDetailResponseDto> viewDetailBookReport(Long bookReportId, Long userId) {
 
-        Optional<BookReport> bookReportOptional = bookReportQueryRepository.findById(bookReportId, userId);
-        String bookReportTag = bookReportTagRepository.findByBookReportId(bookReportId);
+        Optional<BookReportDetailResponseDto> bookReportOptional = bookReportQueryRepository.findById(bookReportId, userId);
 
-        BookReportTag reportTag = BookReportTag.builder().tagName(bookReportTag).build();
 
         if (bookReportOptional.isEmpty()) { // 독서 기록이 비어 있다면?
             return DefaultRes.response(HttpStatus.OK.value(), "데이터없음");
 
         } else {                            // 독서 기록 내용이 있다면?
 
-            return bookReportOptional.map(bookReport -> DefaultRes.response(HttpStatus.OK.value(), "조회성공", new BookReportDetailResponseDto(bookReport, reportTag)))
+            return bookReportOptional.map(bookReport -> DefaultRes.response(HttpStatus.OK.value(), "조회성공", new BookReportDetailResponseDto(bookReportOptional)))
                     .orElseGet(() -> DefaultRes.response(HttpStatus.OK.value(), "조회실패"));
         } // if-else 끝
     } // viewDetailBookReport() 끝
 
     // 독서 기록 수정 Method
     public DefaultRes updateReport(BookreportUpdateRequestDto updateRequestDto, Long bookReportId, Long userId) {  // updateDto, 글번호, 유저 ID
-        Optional<BookReport> optionalBookReport = bookReportQueryRepository.findById(bookReportId, userId);
+        Optional<BookReport> optionalBookReport = bookReportQueryRepository.findByBookReportId(bookReportId, userId);
 
         if (optionalBookReport.isEmpty()) { // 대상 게시물이 없다면?
             DefaultRes.response(HttpStatus.OK.value(), "내용없음");
@@ -106,7 +104,7 @@ public class BookreportService {
 
     // 독서 기록 삭제 Method
     public DefaultRes deleteReport(Long bookReportId, Long userId) {    // 게시글 번호, User 번호
-        Optional<BookReport> bookReportOptional = bookReportQueryRepository.findById(bookReportId, userId);
+        Optional<BookReport> bookReportOptional = bookReportQueryRepository.findByBookReportId(bookReportId, userId);
 
         if (bookReportOptional.isEmpty()) { // 대상 게시물이 없다면?
             return DefaultRes.response(HttpStatus.OK.value(), "내용없음");


### PR DESCRIPTION
### 작업 사항
<br>
- 완료 목록<br>
독서 기록 URI 수정
Bug 수정
<br><br>
- 진행 중 목록<br>
사전에 계획된 기능 구현 모두 완료
<br>

### 요약

1. 독서 기록 게시판 URI 수정
* 독서 기록 게시판 권한에 따른 REST API URI 수정 (블랙 회원, 일반 회원, 관리자 글 등록, 조회, 수정, 삭제 가능)

2. Bug 수정
* 전체 조회 시 Tag 내용을 가져오지 못해 NULL로 담기는 사항 수정
* 상세 조회 시 Tag 내용이 NULL일 때, 500 Error가 나는 사항 수정
<br>

### 첨부

*PostMan Test*

1. 독서 기록 게시판 내용 등록
![image](https://user-images.githubusercontent.com/76773429/124743449-ba42fb00-df58-11eb-8f8a-7c535d914062.png)

---

2. 독서 기록 게시판 전체 조회
![image](https://user-images.githubusercontent.com/76773429/124743544-cfb82500-df58-11eb-9b05-7071e004e28d.png)

---

3. 독서 기록 게시판 상세 조회
![image](https://user-images.githubusercontent.com/76773429/124743713-f6765b80-df58-11eb-8cb3-08747a932d64.png)

---

4. 독서 기록 게시판 내용 수정
![image](https://user-images.githubusercontent.com/76773429/124743801-0beb8580-df59-11eb-8f5b-0bf4fe82c765.png)

---

5. 독서 기록 게시판 내용 삭제
![image](https://user-images.githubusercontent.com/76773429/124743902-2b82ae00-df59-11eb-976f-57922327712b.png)

---

### 이슈
#140 [독서 기록 게시판 URI 수정 및 Bug 수정](https://github.com/woo00oo/goGetterProjectServer/issues/140)