### PR TITLE
[Message-send] 쪽지 발송 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/message/MessageSenderController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/message/MessageSenderController.java
@@ -1,0 +1,47 @@
+package udodog.goGetterServer.controller.api.message;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.message.MessageSenderRequestDto;
+import udodog.goGetterServer.service.message.MessageSenderService;
+
+import javax.validation.Valid;
+
+@Api(tags = {"쪽지 발송 API"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MessageSenderController {
+
+    private final MessageSenderService messageSenderService;
+
+    @ApiOperation(value = "쪽지 발송 API",notes = "사용자가 쪽지를 전송할때 사용하는 API 입니다. (블랙회원 사용 x)")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 등록성공"),
+            @ApiResponse(code=422, message = "1. 발신자정보없음 \n 2. 수신자정보없음")
+    })
+    @PostMapping("/users/messages")
+    public ResponseEntity<DefaultRes> messageSender(
+            @Valid @RequestBody MessageSenderRequestDto request
+            ){
+
+        DefaultRes result = messageSenderService.messageSender(request);
+
+        if(result.getStatusCode() == HttpStatus.OK.value()){
+            return new ResponseEntity<>(result, HttpStatus.OK);
+        }else{
+            return new ResponseEntity<>(result, HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/request/message/MessageSenderRequestDto.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/message/MessageSenderRequestDto.java
@@ -1,0 +1,24 @@
+package udodog.goGetterServer.model.dto.request.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageSenderRequestDto {
+
+    @NotNull
+    private Long senderId;
+
+    @NotNull
+    private Long receiverId;
+
+    @NotEmpty
+    private String content;
+
+}

--- a/src/main/java/udodog/goGetterServer/model/entity/Message.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/Message.java
@@ -35,11 +35,10 @@ public class Message {
     private Boolean isDeleted;
 
     @Builder
-    public Message(User receiver, User sender, String content, LocalDateTime sendAt) {
+    public Message(User receiver, User sender, String content) {
         this.receiver = receiver;
         this.sender = sender;
         this.content = content;
-        this.sendAt = sendAt;
         this.isChecked = false;
         this.isDeleted = false;
     }

--- a/src/main/java/udodog/goGetterServer/service/message/MessageSenderService.java
+++ b/src/main/java/udodog/goGetterServer/service/message/MessageSenderService.java
@@ -1,0 +1,41 @@
+package udodog.goGetterServer.service.message;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.message.MessageSenderRequestDto;
+import udodog.goGetterServer.model.entity.Message;
+import udodog.goGetterServer.model.entity.User;
+import udodog.goGetterServer.repository.MessageRepository;
+import udodog.goGetterServer.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MessageSenderService {
+
+    private final MessageRepository messageRepository;
+
+    private final UserRepository userRepository;
+
+    public DefaultRes messageSender(MessageSenderRequestDto request){
+
+        Long senderId = request.getSenderId();
+        Long receiverId = request.getReceiverId();
+
+        Optional<User> optionalSender = userRepository.findById(senderId);
+        Optional<User> optionalReceiver = userRepository.findById(receiverId);
+
+        return optionalSender.map(sender -> {
+            return optionalReceiver.map(receiver->{
+                messageRepository.save(new Message(sender, receiver, request.getContent()));
+                return DefaultRes.response(HttpStatus.OK.value(), "전송성공");
+            }).orElseGet(() -> DefaultRes.response(HttpStatus.UNPROCESSABLE_ENTITY.value(), "수신자정보없음"));
+        }).orElseGet(() -> DefaultRes.response(HttpStatus.UNPROCESSABLE_ENTITY.value(), "발신자정보없음"));
+
+
+    }
+}

--- a/src/test/java/udodog/goGetterServer/controller/api/message/MessageSenderControllerTest.java
+++ b/src/test/java/udodog/goGetterServer/controller/api/message/MessageSenderControllerTest.java
@@ -1,0 +1,79 @@
+package udodog.goGetterServer.controller.api.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import udodog.goGetterServer.config.WebMvcConfig;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.service.message.MessageSenderService;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(MessageSenderController.class)
+@Slf4j
+public class MessageSenderControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    MessageSenderService messageSenderService;
+
+    @MockBean
+    WebMvcConfig webMvcConfig;
+
+    @Test
+    public void 쪽지_전송_성공() throws Exception {
+
+
+        DefaultRes result = new DefaultRes(HttpStatus.OK.value(), "전송성공", null, null);
+        given(messageSenderService.messageSender(any())).willReturn(result);
+
+
+        mvc.perform(post("/api/users/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"content\": \"안녕하세요\",\n" +
+                        "  \"receiver_id\": 1,\n" +
+                        "  \"sender_id\": 2\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", equalTo(result.getMessage())));
+
+    }
+
+    @Test
+    public void 쪽지_전송_실패() throws Exception {
+
+
+        DefaultRes result = new DefaultRes(HttpStatus.UNPROCESSABLE_ENTITY.value(), "수신자정보없음", null, null);
+        given(messageSenderService.messageSender(any())).willReturn(result);
+
+
+        mvc.perform(post("/api/users/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"content\": \"안녕하세요\",\n" +
+                        "  \"receiver_id\": 1,\n" +
+                        "  \"sender_id\": 2\n" +
+                        "}"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.message", equalTo(result.getMessage())));
+
+    }
+
+}

--- a/src/test/java/udodog/goGetterServer/service/message/MessageSenderServiceTest.java
+++ b/src/test/java/udodog/goGetterServer/service/message/MessageSenderServiceTest.java
@@ -1,0 +1,84 @@
+package udodog.goGetterServer.service.message;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.message.MessageSenderRequestDto;
+import udodog.goGetterServer.model.entity.User;
+import udodog.goGetterServer.repository.MessageRepository;
+import udodog.goGetterServer.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+public class MessageSenderServiceTest {
+
+    @InjectMocks
+    MessageSenderService messageSenderService;
+
+    @Mock
+    MessageRepository messageRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Test
+    public void 쪽지_전송_성공(){
+        //given
+        User user1 = new User();
+        User user2 = new User();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user1));
+        given(userRepository.findById(2L)).willReturn(Optional.of(user2));
+
+        //when
+        DefaultRes defaultRes = messageSenderService.messageSender(new MessageSenderRequestDto(1L, 2L, "안녕하세요"));
+
+        //then
+        assertThat(defaultRes.getMessage()).isEqualTo("전송성공");
+        assertThat(defaultRes.getStatusCode()).isEqualTo(200);
+    }
+
+    @Test
+    public void 쪽지_전송_실패_발신자없음(){
+        //given
+        User user1 = new User();
+        User user2 = new User();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user1));
+        given(userRepository.findById(2L)).willReturn(Optional.of(user2));
+
+        //when
+        DefaultRes defaultRes = messageSenderService.messageSender(new MessageSenderRequestDto(3L, 2L, "안녕하세요"));
+
+        //then
+        assertThat(defaultRes.getMessage()).isEqualTo("발신자정보없음");
+        assertThat(defaultRes.getStatusCode()).isEqualTo(422);
+    }
+
+    @Test
+    public void 쪽지_전송_실패_수신자없음(){
+        //given
+        User user1 = new User();
+        User user2 = new User();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user1));
+        given(userRepository.findById(2L)).willReturn(Optional.of(user2));
+
+        //when
+        DefaultRes defaultRes = messageSenderService.messageSender(new MessageSenderRequestDto(1L, 3L, "안녕하세요"));
+
+        //then
+        assertThat(defaultRes.getMessage()).isEqualTo("수신자정보없음");
+        assertThat(defaultRes.getStatusCode()).isEqualTo(422);
+    }
+
+
+
+}


### PR DESCRIPTION
### 작업 사항

#### 완료 목록

- 쪽지 발송 API 구현

### 요약

클라이언트로부터 발신자, 수신자, 쪽지내용을 요청 받아 message 테이블에 저장.
발신자, 수신자가 user 정보에 없을 경우 422 상태 코드 반환.
테스트 코드 작성, 스웨거 API 문서화.

### 첨부

작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
issued : #150