### PR TITLE
Feat #155 : 쪽지 알림 API 구현

### DIFF
--- a/src/main/java/udodog/goGetterServer/controller/api/message/MessageNotificationController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/message/MessageNotificationController.java
@@ -1,0 +1,39 @@
+package udodog.goGetterServer.controller.api.message;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.message.MessageNotificationRequest;
+import udodog.goGetterServer.model.dto.response.message.MessageNotificationResponse;
+import udodog.goGetterServer.service.message.MessageNotificationService;
+
+
+@Api(tags = {"쪽지 알림 API"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MessageNotificationController {
+
+    private final MessageNotificationService messageNotificationService;
+
+    @ApiOperation(value = "쪽지 알림 API",notes = "읽지 않은 쪽지의 개수를 알림으로 표출해주는 API 입니다. (블랙회원 사용 o)")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 조회 성공 2. 알림 미수신 설정"),
+    })
+    @GetMapping("/bkusers/messages/notice")
+    public ResponseEntity<DefaultRes<MessageNotificationResponse>> messageNotification(@RequestBody MessageNotificationRequest request) {
+
+        return new ResponseEntity<>(messageNotificationService.messageNotification(request), HttpStatus.OK);
+    }
+
+
+}

--- a/src/main/java/udodog/goGetterServer/controller/api/sharingboard/SharingReplyController.java
+++ b/src/main/java/udodog/goGetterServer/controller/api/sharingboard/SharingReplyController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import udodog.goGetterServer.model.converter.sharingboard.SharingReplyConverter;
 import udodog.goGetterServer.model.dto.DefaultRes;
-import udodog.goGetterServer.model.dto.request.UpdateSharingReplyRequest;
+import udodog.goGetterServer.model.dto.request.sharingboard.UpdateSharingReplyRequest;
 import udodog.goGetterServer.model.dto.request.sharingboard.CreateSharingReplyRequest;
 import udodog.goGetterServer.model.dto.request.sharingboard.DeleteSharingReplyRequest;
 import udodog.goGetterServer.model.dto.response.sharingboard.SharingReplyResponse;

--- a/src/main/java/udodog/goGetterServer/model/dto/request/message/MessageNotificationRequest.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/message/MessageNotificationRequest.java
@@ -1,0 +1,16 @@
+package udodog.goGetterServer.model.dto.request.message;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class MessageNotificationRequest {
+
+    @NotNull
+    @ApiModelProperty(value = "현재 로그인중인 사용자의 userId")
+    private Long receiverId;
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/request/sharingboard/CreateBoardRequest.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/sharingboard/CreateBoardRequest.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 
-
 @Getter
 @NoArgsConstructor
 public class CreateBoardRequest {

--- a/src/main/java/udodog/goGetterServer/model/dto/request/sharingboard/UpdateSharingReplyRequest.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/request/sharingboard/UpdateSharingReplyRequest.java
@@ -1,4 +1,4 @@
-package udodog.goGetterServer.model.dto.request;
+package udodog.goGetterServer.model.dto.request.sharingboard;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;

--- a/src/main/java/udodog/goGetterServer/model/dto/response/message/MessageNotificationResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/message/MessageNotificationResponse.java
@@ -1,0 +1,15 @@
+package udodog.goGetterServer.model.dto.response.message;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MessageNotificationResponse {
+
+    Long uncheckedMessageCnt;
+
+    public MessageNotificationResponse(Long uncheckedMessageCnt) {
+        this.uncheckedMessageCnt = uncheckedMessageCnt;
+    }
+}

--- a/src/main/java/udodog/goGetterServer/model/dto/response/sharingboard/SharingReplyResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/sharingboard/SharingReplyResponse.java
@@ -2,10 +2,8 @@ package udodog.goGetterServer.model.dto.response.sharingboard;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import udodog.goGetterServer.model.entity.SharingBoardReply;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor

--- a/src/main/java/udodog/goGetterServer/model/dto/response/sharingboard/SimpleBoardResponse.java
+++ b/src/main/java/udodog/goGetterServer/model/dto/response/sharingboard/SimpleBoardResponse.java
@@ -1,7 +1,6 @@
 package udodog.goGetterServer.model.dto.response.sharingboard;
 
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
 import udodog.goGetterServer.model.entity.SharingBoard;
 
 import java.time.LocalDateTime;

--- a/src/main/java/udodog/goGetterServer/model/entity/SharingBoardReply.java
+++ b/src/main/java/udodog/goGetterServer/model/entity/SharingBoardReply.java
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-import udodog.goGetterServer.model.dto.request.UpdateSharingReplyRequest;
+import udodog.goGetterServer.model.dto.request.sharingboard.UpdateSharingReplyRequest;
 import udodog.goGetterServer.model.dto.request.sharingboard.CreateSharingReplyRequest;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/udodog/goGetterServer/repository/MessageRepository.java
+++ b/src/main/java/udodog/goGetterServer/repository/MessageRepository.java
@@ -3,7 +3,8 @@ package udodog.goGetterServer.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import udodog.goGetterServer.model.entity.Message;
+import udodog.goGetterServer.repository.querydsl.message.MessageNotificationExtension;
 
 @Repository
-public interface MessageRepository extends JpaRepository<Message,Long> {
+public interface MessageRepository extends JpaRepository<Message,Long>, MessageNotificationExtension {
 }

--- a/src/main/java/udodog/goGetterServer/repository/querydsl/message/MessageNotificationExtension.java
+++ b/src/main/java/udodog/goGetterServer/repository/querydsl/message/MessageNotificationExtension.java
@@ -1,0 +1,6 @@
+package udodog.goGetterServer.repository.querydsl.message;
+
+public interface MessageNotificationExtension {
+
+    Long countUncheckedMessage(Long receiverId);
+}

--- a/src/main/java/udodog/goGetterServer/repository/querydsl/message/MessageNotificationExtensionImpl.java
+++ b/src/main/java/udodog/goGetterServer/repository/querydsl/message/MessageNotificationExtensionImpl.java
@@ -1,0 +1,24 @@
+package udodog.goGetterServer.repository.querydsl.message;
+
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import udodog.goGetterServer.model.entity.Message;
+import udodog.goGetterServer.model.entity.QMessage;
+
+public class MessageNotificationExtensionImpl  extends QuerydslRepositorySupport implements MessageNotificationExtension {
+
+    public MessageNotificationExtensionImpl() {
+        super(Message.class);
+    }
+
+    @Override
+    public Long countUncheckedMessage(Long receiverId) {
+        QMessage message = QMessage.message;
+
+        Long uncheckedCnt = from(message)
+                .where(message.receiver.id.eq(receiverId))
+                .where(message.isChecked.isFalse()).fetchCount();
+
+        return uncheckedCnt;
+    }
+}

--- a/src/main/java/udodog/goGetterServer/service/message/MessageNotificationService.java
+++ b/src/main/java/udodog/goGetterServer/service/message/MessageNotificationService.java
@@ -1,0 +1,24 @@
+package udodog.goGetterServer.service.message;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import udodog.goGetterServer.model.dto.DefaultRes;
+import udodog.goGetterServer.model.dto.request.message.MessageNotificationRequest;
+import udodog.goGetterServer.model.dto.response.message.MessageNotificationResponse;
+import udodog.goGetterServer.repository.MessageRepository;
+
+
+@Service
+@RequiredArgsConstructor
+public class MessageNotificationService {
+
+    private final MessageRepository messageRepository;
+
+    public DefaultRes<MessageNotificationResponse> messageNotification(MessageNotificationRequest request) {
+        Long receiverId = request.getReceiverId();
+        Long uncheckedMessageCnt = messageRepository.countUncheckedMessage(receiverId);
+
+        return DefaultRes.response(HttpStatus.OK.value(),"조회 성공", new MessageNotificationResponse(uncheckedMessageCnt));
+    }
+}

--- a/src/main/java/udodog/goGetterServer/service/sharingboard/SharingReplyService.java
+++ b/src/main/java/udodog/goGetterServer/service/sharingboard/SharingReplyService.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import udodog.goGetterServer.model.dto.DefaultRes;
 import udodog.goGetterServer.model.dto.Pagination;
-import udodog.goGetterServer.model.dto.request.UpdateSharingReplyRequest;
+import udodog.goGetterServer.model.dto.request.sharingboard.UpdateSharingReplyRequest;
 import udodog.goGetterServer.model.dto.request.sharingboard.CreateSharingReplyRequest;
 import udodog.goGetterServer.model.dto.request.sharingboard.DeleteSharingReplyRequest;
 import udodog.goGetterServer.model.dto.response.sharingboard.SharingReplyResponse;


### PR DESCRIPTION
사용자에게 온 읽지 않은 쪽지 개수 조회 API 구현 및 스웨거 문서

- 194번 사용자의 읽지 않은 쪽지 개수 : 4개
![스크린샷(240)](https://user-images.githubusercontent.com/62657545/125067983-e5ac1e00-e0ef-11eb-8f45-8cf48147911a.png)


- 194번 사용자에게 온 읽지 않은 쪽지 개수 조회 -> 4개
![스크린샷(239)](https://user-images.githubusercontent.com/62657545/125068060-ff4d6580-e0ef-11eb-8741-c08754913a63.png)


- 194번 사용자의 읽지 않은 쪽지 2개 읽음 처리 
![스크린샷(241)](https://user-images.githubusercontent.com/62657545/125068131-19874380-e0f0-11eb-9012-f8f827f9021c.png)

- 쪽지 2개 읽음 처리 후 194번 사용자에게 온 읽지 않은 쪽지 개수 조회 -> 2개
![스크린샷(242)](https://user-images.githubusercontent.com/62657545/125068202-2f950400-e0f0-11eb-9db7-75ada32a1c21.png)
